### PR TITLE
Fix `PDFDocument` Text, Make `totalAmount` Dependent on `quantity`

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -1,8 +1,9 @@
 {
   "invoices": {
     "pdf": {
-      "title": "VAT INVOICE",
-      "series_label": "Invoice series",
+      "businessTitle": "VAT INVOICE",
+      "individualTitle": "INVOICE",
+      "series_label": "Invoice Series",
       "invoice_number_label": "No.",
       "provider_label": "Provider:",
       "business_number_business": "Company code:",

--- a/client/messages/lt.json
+++ b/client/messages/lt.json
@@ -1,6 +1,8 @@
 {
   "invoices": {
     "pdf": {
+      "individualTitle": "SĄSKAITA FAKTŪRA",
+      "businessTitle": "PVM SĄSKAITA FAKTŪRA",
       "title": "PVM SĄSKAITA FAKTŪRA",
       "series_label": "Sąskaitos serija",
       "invoice_number_label": "Nr.",

--- a/client/src/components/invoice/InvoiceModal.tsx
+++ b/client/src/components/invoice/InvoiceModal.tsx
@@ -6,7 +6,7 @@ import useGetBankAccount from "@/lib/hooks/banking-information/useGetBankAccount
 import useGetUser from "@/lib/hooks/user/useGetUser";
 import { InvoiceModel } from "@/lib/types/models/invoice";
 
-import PDFDocument from "../pdf/PDFDocument";
+import PDFDocument from "../pdf/pdf-document";
 
 type Props = {
   userId: number;

--- a/client/src/components/invoice/InvoiceServicesTable.tsx
+++ b/client/src/components/invoice/InvoiceServicesTable.tsx
@@ -27,7 +27,6 @@ const INVOICE_SERVICE_COLUMNS = [
   { name: "AMOUNT", uid: "amount" },
   { name: "ACTION", uid: "actions" },
 ];
-
 const INITIAL_GRAND_TOTAL = 0;
 
 type Props = {
@@ -56,8 +55,9 @@ const InvoiceServicesTable = ({
   });
 
   // watching the entire services array doesn't work, individual services have to be selected
-  const serviceAmounts = fields.map((_field, index) =>
-    watch(`services.${index}.amount`),
+  const serviceAmounts = fields.map(
+    (_field, index) =>
+      watch(`services.${index}.amount`) * watch(`services.${index}.quantity`),
   );
 
   const totalAmount = useMemo(

--- a/client/src/components/pdf/pdf-document.tsx
+++ b/client/src/components/pdf/pdf-document.tsx
@@ -26,14 +26,14 @@ type Props = {
   language: string;
 };
 
-const PDFDocument = ({
+export default function PDFDocument({
   t,
   invoiceData,
   senderSignatureImage,
   bankAccount,
   currency,
   language,
-}: Props) => {
+}: Props) {
   const { date, dueDate, invoiceId, receiver, sender, services, totalAmount } =
     invoiceData;
 
@@ -50,10 +50,14 @@ const PDFDocument = ({
 
   const renderHeader = () => (
     <>
-      <Text style={styles.title}>{t("title")}</Text>
+      <Text style={styles.title}>
+        {invoiceData.sender.businessType === "business"
+          ? t("businessTitle")
+          : t("individualTitle")}{" "}
+      </Text>
       <Text style={styles.subtitle}>
         {t("series_label")} <Text style={styles.boldText}>{series}</Text>{" "}
-        Nr.&nbsp;
+        {t("invoice_number_label")}&nbsp;
         <Text style={styles.boldText}>{number}</Text>
       </Text>
     </>
@@ -237,6 +241,4 @@ const PDFDocument = ({
       </Page>
     </Document>
   );
-};
-
-export default PDFDocument;
+}


### PR DESCRIPTION
## Overview
- Invoice `totalAmount` is now based on each service's amount multiplied by the quantity
- Generated invoice's title text only includes `VAT` if the invoice's sender's business type is `'business'`