### PR TITLE
Fix: `bankingInformation`'s and `receiver`'s Optional `id` Fields

### DIFF
--- a/server/src/types/models/invoice.ts
+++ b/server/src/types/models/invoice.ts
@@ -73,7 +73,7 @@ export const Invoice = Type.Object({
   // ),
   receiver: Type.Object(
     {
-      id: Type.Number(),
+      id: Type.Optional(Type.Number()),
       type: InvoicePartyType,
       name: Type.String({ minLength: 1, errorMessage: "errors.invoice.name" }),
       businessType: InvoicePartyBusinessType,
@@ -108,7 +108,7 @@ export const Invoice = Type.Object({
   }),
   bankingInformation: Type.Object(
     {
-      id: Type.Number(),
+      id: Type.Optional(Type.Number()),
       name: Type.String(),
       code: Type.String(),
       accountNumber: Type.String(),


### PR DESCRIPTION
### Overview
Under `receiver` and `bankingInformation` the `id` fields were required which prevented the invoice from being created. In this PR I have added a `Type.Optional()` wrapper to fix that.