### PR TITLE
[REK-63]: improve shared types dev watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ pnpm run server migrate
 - Server uses Zod for runtime validation
 - Client imports inferred TypeScript types (no runtime validation)
 - Automatic type safety across the entire stack
+- `pnpm dev` builds `@invoicetrackr/types` once before starting dev servers.
+  The shared types package then runs in watch mode, and client/server dev
+  servers are configured to pick up rebuilt package output from
+  `shared/types/dist`.
 
 ### API Structure
 - Controllers handle business logic (`server/src/controllers/`)

--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -20,6 +20,7 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 const nextConfig = {
+  transpilePackages: ['@invoicetrackr/types'],
   experimental: {
     authInterrupts: true
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "server": "pnpm --filter @invoicetrackr/server",
     "types": "pnpm --filter @invoicetrackr/types",
     "emails": "pnpm --filter @invoicetrackr/emails",
-    "dev": "concurrently \"pnpm run types dev\" \"pnpm run server dev\" \"pnpm run client dev:turbo\"",
+    "dev": "pnpm run types build && concurrently \"pnpm run types dev\" \"pnpm run server dev\" \"pnpm run client dev:turbo\"",
     "build": "pnpm run types build && pnpm run emails build && pnpm run server build && pnpm run client build",
     "lint": "pnpm run client lint && pnpm run server lint",
     "lint:fix": "pnpm run client lint:fix && pnpm run server lint:fix",

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/app.js",
-    "dev": "tsx watch src/app.ts",
+    "dev": "tsx watch --include ../shared/types/dist/**/* src/app.ts",
     "tsc": "tsc -p tsconfig.json --noEmit",
     "generate": "drizzle-kit generate",
     "migrate": "drizzle-kit migrate",


### PR DESCRIPTION
### Overview

Improves the local development workflow for `@invoicetrackr/types` so shared type changes become available during `pnpm dev` without restarting the whole workspace.

- Builds shared types once before starting dev servers to avoid stale or missing `shared/types/dist` output.
- Keeps `@invoicetrackr/types` running in watch mode during `pnpm dev`.
- Configures the server watcher to restart when rebuilt shared type output changes.
- Configures Next to transpile the workspace types package so client dev picks up package changes.
- Documents the dev-time shared types workflow.