### PR TITLE
[REK-65] Wire invoice domain fields into frontend UI

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -264,8 +264,14 @@
         "receiver": "RECEIVER",
         "amount": "AMOUNT",
         "date": "DATE",
+        "lifecycle_status": "LIFECYCLE",
         "status": "STATUS",
         "actions": "ACTIONS"
+      },
+      "lifecycle_status": {
+        "draft": "Draft",
+        "issued": "Issued",
+        "voided": "Voided"
       },
       "status": {
         "paid": "Paid",
@@ -338,6 +344,10 @@
       "unit_label": "Unit",
       "quantity_label": "Qty",
       "amount_label": "Amount",
+      "vat_rate_label": "VAT",
+      "line_total_label": "Line total",
+      "subtotal_amount": "Subtotal",
+      "vat_amount": "VAT total",
       "total_amount": "Total",
       "cents": "{cents} c",
       "invoice_issued_by_label": "Issued by:",
@@ -650,8 +660,12 @@
       "column_unit": "UNIT",
       "column_quantity": "QUANTITY",
       "column_amount": "AMOUNT",
+      "column_vat_rate": "VAT",
+      "column_line_total": "TOTAL",
       "column_actions": "ACTION",
       "add_service": "Add Service",
+      "subtotal": "Subtotal",
+      "vat_total": "VAT Total",
       "grand_total": "Grand Total",
       "delete_service": "Delete service",
       "a11y": {
@@ -661,6 +675,7 @@
         "unit_label": "Unit",
         "quantity_label": "Quantity",
         "amount_label": "Amount",
+        "vat_rate_label": "VAT Rate",
         "actions_label": "Actions"
       }
     },

--- a/client/messages/lt.json
+++ b/client/messages/lt.json
@@ -264,8 +264,14 @@
         "receiver": "GAVĖJAS",
         "amount": "SUMA",
         "date": "DATA",
+        "lifecycle_status": "GYVAVIMO CIKLAS",
         "status": "BŪSENA",
         "actions": "VEIKSMAI"
+      },
+      "lifecycle_status": {
+        "draft": "Juodraštis",
+        "issued": "Išrašyta",
+        "voided": "Anuliuota"
       },
       "status": {
         "paid": "Sumokėta",
@@ -338,6 +344,10 @@
       "unit_label": "Vnt.",
       "quantity_label": "Kiekis",
       "amount_label": "Suma",
+      "vat_rate_label": "PVM",
+      "line_total_label": "Eilutės suma",
+      "subtotal_amount": "Suma be PVM",
+      "vat_amount": "PVM suma",
       "total_amount": "Viso",
       "cents": "{cents} ct",
       "invoice_issued_by_label": "Sąskaitą išrašė:",
@@ -650,8 +660,12 @@
       "column_unit": "VIENETAS",
       "column_quantity": "KIEKIS",
       "column_amount": "SUMA",
+      "column_vat_rate": "PVM",
+      "column_line_total": "VISO",
       "column_actions": "VEIKSMAI",
       "add_service": "Pridėti paslaugą",
+      "subtotal": "Suma be PVM",
+      "vat_total": "PVM suma",
       "grand_total": "Bendra suma",
       "delete_service": "Ištrinti paslaugą",
       "a11y": {
@@ -661,6 +675,7 @@
         "unit_label": "Vienetas",
         "quantity_label": "Kiekis",
         "amount_label": "Suma",
+        "vat_rate_label": "PVM tarifas",
         "actions_label": "Veiksmai"
       }
     },

--- a/client/src/components/invoice/free-invoice-form.tsx
+++ b/client/src/components/invoice/free-invoice-form.tsx
@@ -9,8 +9,8 @@ import { useTranslations } from 'next-intl';
 
 import { Currency } from '@/lib/types/currency';
 import { HOME_PAGE } from '@/lib/constants/pages';
-import { InvoiceBody } from '@invoicetrackr/types';
-import { calculateServiceTotal } from '@/lib/utils';
+import type { InvoiceBody } from '@invoicetrackr/types';
+import { calculateInvoiceTotals } from '@/lib/utils';
 import { formatDate } from '@/lib/utils/date';
 
 import InvoiceModal from './invoice-modal';
@@ -47,7 +47,9 @@ const FreeInvoiceForm = ({ language, currency }: Props) => {
         email: '',
         type: 'receiver' as const
       },
-      services: [{ amount: 0, quantity: 0, description: '', unit: '' }],
+      services: [
+        { amount: 0, quantity: 0, description: '', unit: '', vatRate: 0 }
+      ],
       bankingInformation: { name: '', code: '', accountNumber: '' }
     }
   });
@@ -289,13 +291,21 @@ const FreeInvoiceForm = ({ language, currency }: Props) => {
     </div>
   );
 
+  const getInvoicePreviewData = () => {
+    const invoiceTotals = calculateInvoiceTotals(getValues('services'));
+
+    return {
+      ...getValues(),
+      subtotalAmount: invoiceTotals.subtotalAmount,
+      vatAmount: invoiceTotals.vatAmount,
+      totalAmount: invoiceTotals.totalAmount
+    };
+  };
+
   const renderPdfDocument = () => (
     <PDFDocument
       currency={currency}
-      invoiceData={{
-        ...getValues(),
-        totalAmount: calculateServiceTotal(getValues('services')).toString()
-      }}
+      invoiceData={getInvoicePreviewData()}
       senderSignatureImage={senderSignatureImage}
       t={pdfTranslator}
       language={language}
@@ -305,7 +315,7 @@ const FreeInvoiceForm = ({ language, currency }: Props) => {
   return (
     <>
       <FormProvider {...methods}>
-        <div className="mx-auto max-w-5xl p-6">
+        <div className="mx-auto max-w-7xl p-6">
           <div className="flex flex-col gap-2">
             <h1 className="text-3xl font-semibold">
               {t('free_invoice.title')}
@@ -363,10 +373,7 @@ const FreeInvoiceForm = ({ language, currency }: Props) => {
 
       <InvoiceModal
         pdfDocument={renderPdfDocument()}
-        invoiceData={{
-          ...getValues(),
-          totalAmount: calculateServiceTotal(getValues('services')).toString()
-        }}
+        invoiceData={getInvoicePreviewData()}
         invoiceLanguage={language}
         isOpen={isInvoiceModalOpen}
         onOpenChange={setIsInvoiceModalOpen}

--- a/client/src/components/invoice/invoice-form.tsx
+++ b/client/src/components/invoice/invoice-form.tsx
@@ -21,10 +21,10 @@ import {
   useForm
 } from 'react-hook-form';
 import { useRef, useState } from 'react';
-import { Client } from '@invoicetrackr/types';
+import type { Client } from '@invoicetrackr/types';
 import { useTranslations } from 'next-intl';
 
-import {
+import type {
   BankAccountBody,
   ClientBody,
   InvoiceBody,
@@ -75,7 +75,9 @@ const InvoiceForm = ({
     defaultValues: invoiceData || {
       sender: user,
       receiver: INITIAL_RECEIVER_DATA,
-      services: [{ amount: 0, quantity: 0, description: '', unit: '' }],
+      services: [
+        { amount: 0, quantity: 0, description: '', unit: '', vatRate: 0 }
+      ],
       bankingInformation: { name: '', code: '', accountNumber: '' },
       status: 'pending'
     }

--- a/client/src/components/invoice/invoice-services-table.tsx
+++ b/client/src/components/invoice/invoice-services-table.tsx
@@ -12,16 +12,16 @@ import {
   TableRow,
   Tooltip
 } from '@heroui/react';
-import { InvoiceBody, InvoiceServiceBody } from '@invoicetrackr/types';
-import { Key, useEffect, useMemo } from 'react';
+import type { InvoiceBody, InvoiceServiceBody } from '@invoicetrackr/types';
 import { PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import { useEffect, useMemo } from 'react';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import type { Key } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { Currency } from '@/lib/types/currency';
+import { calculateInvoiceTotals } from '@/lib/utils';
 import { getCurrencySymbol } from '@/lib/utils/currency';
-
-const INITIAL_GRAND_TOTAL = 0;
 
 type Props = {
   invoiceServices?: Array<InvoiceServiceBody>;
@@ -40,7 +40,6 @@ const InvoiceServicesTable = ({
   const {
     register,
     control,
-    watch,
     clearErrors,
     formState: { errors }
   } = useFormContext<InvoiceBody>();
@@ -55,22 +54,33 @@ const InvoiceServicesTable = ({
     { name: t('column_unit'), uid: 'unit' },
     { name: t('column_quantity'), uid: 'quantity' },
     { name: t('column_amount'), uid: 'amount' },
+    { name: t('column_vat_rate'), uid: 'vatRate' },
+    { name: t('column_line_total'), uid: 'lineTotal' },
     { name: t('column_actions'), uid: 'actions' }
   ];
 
-  // watching the entire services array doesn't work, individual services have to be selected
-  const serviceAmounts = fields.map(
-    (_field, index) =>
-      watch(`services.${index}.amount`) * watch(`services.${index}.quantity`)
+  const services =
+    useWatch({
+      control,
+      name: 'services'
+    }) || [];
+
+  const invoiceTotals = useMemo(
+    () => calculateInvoiceTotals(services),
+    [services]
   );
 
-  const totalAmount = useMemo(
+  const lineTotals = useMemo(
     () =>
-      serviceAmounts.reduce(
-        (acc, amount) => acc + (Number(amount) || 0),
-        INITIAL_GRAND_TOTAL
-      ),
-    [serviceAmounts]
+      services.map((service) => {
+        const amount = Number(service?.amount) || 0;
+        const quantity = Number(service?.quantity) || 0;
+        const vatRate = Number(service?.vatRate ?? 0) || 0;
+        const subtotal = amount * quantity;
+
+        return subtotal + subtotal * (vatRate / 100);
+      }),
+    [services]
   );
 
   useEffect(() => {
@@ -80,10 +90,17 @@ const InvoiceServicesTable = ({
   }, [invoiceServices, replace]);
 
   const handleAddService = () => {
-    append({ id: 0, amount: 0, description: '', quantity: 0, unit: '' });
+    append({
+      id: 0,
+      amount: 0,
+      description: '',
+      quantity: 0,
+      unit: '',
+      vatRate: 0
+    });
 
     // Clear errors if there are no services
-    if (!serviceAmounts.length) clearErrors('services');
+    if (!services.length) clearErrors('services');
   };
 
   const handleRemoveService = (index: number) => {
@@ -96,11 +113,21 @@ const InvoiceServicesTable = ({
         <PlusIcon className="h-5 w-5" />
         {t('add_service')}
       </Button>
-      <div className="flex gap-6 self-end pr-3">
-        <p>{t('grand_total')}:</p>
-        <p>
+      <div className="grid min-w-64 grid-cols-[1fr_auto] gap-x-6 gap-y-1 self-end pr-3 text-sm">
+        <p className="text-default-500">{t('subtotal')}:</p>
+        <p className="text-right">
           {getCurrencySymbol(currency)}
-          {totalAmount.toFixed(2)}
+          {invoiceTotals.subtotalAmount}
+        </p>
+        <p className="text-default-500">{t('vat_total')}:</p>
+        <p className="text-right">
+          {getCurrencySymbol(currency)}
+          {invoiceTotals.vatAmount}
+        </p>
+        <p className="font-medium">{t('grand_total')}:</p>
+        <p className="text-right font-medium">
+          {getCurrencySymbol(currency)}
+          {invoiceTotals.totalAmount}
         </p>
       </div>
     </div>
@@ -113,7 +140,7 @@ const InvoiceServicesTable = ({
       case 'description':
         return (
           <Input
-            className="min-w-44"
+            className="min-w-40"
             aria-label={t('a11y.description_label')}
             type="text"
             maxLength={200}
@@ -129,7 +156,7 @@ const InvoiceServicesTable = ({
       case 'unit':
         return (
           <Input
-            className="min-w-44"
+            className="min-w-24"
             aria-label={t('a11y.unit_label')}
             type="text"
             maxLength={20}
@@ -143,6 +170,7 @@ const InvoiceServicesTable = ({
       case 'quantity':
         return (
           <Input
+            className="min-w-24"
             aria-label={t('a11y.quantity_label')}
             type="number"
             defaultValue={
@@ -157,6 +185,7 @@ const InvoiceServicesTable = ({
       case 'amount':
         return (
           <Input
+            className="min-w-36"
             aria-label={t('a11y.amount_label')}
             type="number"
             defaultValue={
@@ -167,6 +196,32 @@ const InvoiceServicesTable = ({
             isInvalid={!!errors.services?.[index]?.amount}
             errorMessage={errors.services?.[index]?.amount?.message}
           />
+        );
+      case 'vatRate':
+        return (
+          <Input
+            className="w-20 min-w-20"
+            aria-label={t('a11y.vat_rate_label')}
+            type="number"
+            min={0}
+            max={100}
+            step="0.01"
+            endContent={<span className="text-default-400 text-sm">%</span>}
+            defaultValue={
+              (fields[index] as InvoiceServiceBody).vatRate?.toString() || '0'
+            }
+            variant="bordered"
+            {...register(`services.${index}.vatRate`)}
+            isInvalid={!!errors.services?.[index]?.vatRate}
+            errorMessage={errors.services?.[index]?.vatRate?.message}
+          />
+        );
+      case 'lineTotal':
+        return (
+          <p className="min-w-24 text-right text-sm font-medium">
+            {getCurrencySymbol(currency)}
+            {(lineTotals[index] || 0).toFixed(2)}
+          </p>
         );
       case 'actions':
         return (

--- a/client/src/components/invoice/invoice-table-cell.tsx
+++ b/client/src/components/invoice/invoice-table-cell.tsx
@@ -19,10 +19,15 @@ import {
   PencilSquareIcon,
   TrashIcon
 } from '@heroicons/react/24/outline';
-import { JSX, Key, useEffect, useState, useTransition } from 'react';
+import type { JSX, Key } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
 
-import { InvoiceBody, InvoiceStatus } from '@invoicetrackr/types';
+import type {
+  InvoiceBody,
+  InvoiceLifecycleStatus,
+  InvoiceStatus
+} from '@invoicetrackr/types';
 import { Currency } from '@/lib/types/currency';
 import { formatDate } from '@/lib/utils/date';
 import { getCurrencySymbol } from '@/lib/utils/currency';
@@ -36,6 +41,15 @@ const statusColorMap: Record<InvoiceStatus, 'success' | 'danger' | 'warning'> =
     pending: 'warning',
     canceled: 'danger'
   };
+
+const lifecycleStatusColorMap: Record<
+  InvoiceLifecycleStatus,
+  'default' | 'primary' | 'danger'
+> = {
+  draft: 'default',
+  issued: 'primary',
+  voided: 'danger'
+};
 
 type Props = {
   userId: number;
@@ -61,6 +75,7 @@ const InvoiceTableCell = ({
 }: Props) => {
   const tCell = useTranslations('invoices.cell.actions');
   const tForm = useTranslations('components.invoice_form');
+  const tTable = useTranslations('invoices.table');
   const [isPaid, setIsPaid] = useState(invoice.status === 'paid');
   const [isPending, startTransition] = useTransition();
 
@@ -149,6 +164,20 @@ const InvoiceTableCell = ({
       );
     case 'date':
       return formatDate(cellValue as string) || '';
+    case 'lifecycleStatus': {
+      const lifecycleStatus = invoice.lifecycleStatus || 'draft';
+
+      return (
+        <Chip
+          className="capitalize"
+          color={lifecycleStatusColorMap[lifecycleStatus]}
+          size="sm"
+          variant="flat"
+        >
+          {tTable(`lifecycle_status.${lifecycleStatus}`)}
+        </Chip>
+      );
+    }
     case 'status':
       return (
         <div className="flex items-center justify-between gap-4">

--- a/client/src/components/invoice/invoice-table.tsx
+++ b/client/src/components/invoice/invoice-table.tsx
@@ -13,7 +13,7 @@ import {
   useDisclosure
 } from '@heroui/react';
 import { useMemo, useState } from 'react';
-import { InvoiceBody } from '@invoicetrackr/types';
+import type { InvoiceBody } from '@invoicetrackr/types';
 import { useTranslations } from 'next-intl';
 
 import { Currency } from '@/lib/types/currency';
@@ -34,6 +34,7 @@ const INITIAL_VISIBLE_COLUMNS = [
   'date',
   'receiver',
   'totalAmount',
+  'lifecycleStatus',
   'status',
   'actions'
 ];
@@ -62,6 +63,11 @@ const InvoiceTable = ({
       { name: t('columns.receiver'), uid: 'receiver', sortable: true },
       { name: t('columns.amount'), uid: 'totalAmount', sortable: true },
       { name: t('columns.date'), uid: 'date', sortable: true },
+      {
+        name: t('columns.lifecycle_status'),
+        uid: 'lifecycleStatus',
+        sortable: true
+      },
       { name: t('columns.status'), uid: 'status', sortable: true },
       { name: t('columns.actions'), uid: 'actions' }
     ],

--- a/client/src/components/pdf/pdf-document.tsx
+++ b/client/src/components/pdf/pdf-document.tsx
@@ -8,9 +8,13 @@ import {
   Text,
   View
 } from '@react-pdf/renderer';
-import { InvoiceBody, InvoiceServiceBody } from '@invoicetrackr/types';
+import type { InvoiceBody, InvoiceServiceBody } from '@invoicetrackr/types';
 
-import { getDaysUntilDueDate, splitInvoiceId } from '@/lib/utils';
+import {
+  calculateInvoiceTotals,
+  getDaysUntilDueDate,
+  splitInvoiceId
+} from '@/lib/utils';
 import { pdfStyles, registerPdfFont } from '@/lib/utils/pdf';
 import { amountToWords } from '@/lib/utils/amount-to-words';
 import { formatDate } from '@/lib/utils/date';
@@ -34,12 +38,18 @@ export default function PDFDocument({
 }: Props) {
   const { date, dueDate, invoiceId, receiver, sender, services, totalAmount } =
     invoiceData;
+  const invoiceTotals = calculateInvoiceTotals(services);
+  const subtotalAmount =
+    invoiceData.subtotalAmount || invoiceTotals.subtotalAmount;
+  const vatAmount = invoiceData.vatAmount || invoiceTotals.vatAmount;
+  const grandTotalAmount = totalAmount || invoiceTotals.totalAmount;
+  const shouldShowVatTotal = Number(vatAmount) > 0;
 
   const splitId = splitInvoiceId(invoiceId);
   const series = splitId[0];
   const number = splitId[1];
 
-  const cents = Math.floor(Number(totalAmount) * 100) % 100;
+  const cents = Math.floor(Number(grandTotalAmount) * 100) % 100;
 
   const renderBusinessNumberLabel = (party: 'sender' | 'receiver') =>
     invoiceData?.[party]?.businessType === 'business'
@@ -114,7 +124,8 @@ export default function PDFDocument({
     description: string,
     unit: string,
     quantity: number,
-    amount: number
+    amount: number,
+    vatRate?: number
   ) => (
     <View style={pdfStyles.tableRow} key={index}>
       <View style={[pdfStyles.tableCol, pdfStyles.tableCol1]}>
@@ -134,17 +145,39 @@ export default function PDFDocument({
           {(Number(amount) || 0).toFixed(2)} {currency.toUpperCase()}
         </Text>
       </View>
+      <View style={[pdfStyles.tableCol, pdfStyles.tableCol6]}>
+        <Text style={pdfStyles.tableCell}>{Number(vatRate ?? 0)}%</Text>
+      </View>
+      <View style={[pdfStyles.tableCol, pdfStyles.tableCol7]}>
+        <Text style={pdfStyles.tableCell}>
+          {(
+            Number(amount) *
+            Number(quantity) *
+            (1 + Number(vatRate ?? 0) / 100)
+          ).toFixed(2)}{' '}
+          {currency.toUpperCase()}
+        </Text>
+      </View>
     </View>
   );
 
-  const renderTotalAmountTableRow = () => (
+  const renderTotalAmountTableRow = (
+    label: string,
+    amount: string,
+    isGrandTotal = false
+  ) => (
     <View style={pdfStyles.totalTableRow}>
       <View style={[pdfStyles.tableCol, pdfStyles.tableCol4]}>
-        <Text style={pdfStyles.tableCellHeader}>{t('total_amount')}</Text>
+        <Text style={pdfStyles.tableCellHeader}>{label}</Text>
       </View>
       <View style={[pdfStyles.tableCol, pdfStyles.tableCol5]}>
-        <Text style={pdfStyles.tableCell}>
-          {Number(invoiceData.totalAmount).toFixed(2)} {currency.toUpperCase()}
+        <Text
+          style={[
+            pdfStyles.tableCell,
+            ...(isGrandTotal ? [pdfStyles.boldText] : [])
+          ]}
+        >
+          {(Number(amount) || 0).toFixed(2)} {currency.toUpperCase()}
         </Text>
       </View>
     </View>
@@ -171,6 +204,14 @@ export default function PDFDocument({
           <View style={[pdfStyles.tableColHeader, pdfStyles.tableCol5]}>
             <Text style={pdfStyles.tableCellHeader}>{t('amount_label')}</Text>
           </View>
+          <View style={[pdfStyles.tableColHeader, pdfStyles.tableCol6]}>
+            <Text style={pdfStyles.tableCellHeader}>{t('vat_rate_label')}</Text>
+          </View>
+          <View style={[pdfStyles.tableColHeader, pdfStyles.tableCol7]}>
+            <Text style={pdfStyles.tableCellHeader}>
+              {t('line_total_label')}
+            </Text>
+          </View>
         </View>
 
         {services.map((service: InvoiceServiceBody, index: number) =>
@@ -179,12 +220,15 @@ export default function PDFDocument({
             service.description,
             service.unit,
             service.quantity,
-            service.amount
+            service.amount,
+            service.vatRate
           )
         )}
       </View>
 
-      {renderTotalAmountTableRow()}
+      {renderTotalAmountTableRow(t('subtotal_amount'), subtotalAmount)}
+      {shouldShowVatTotal && renderTotalAmountTableRow(t('vat_amount'), vatAmount)}
+      {renderTotalAmountTableRow(t('total_amount'), grandTotalAmount, true)}
     </>
   );
 
@@ -269,8 +313,8 @@ export default function PDFDocument({
         {renderTableSection()}
         <View style={pdfStyles.midSection}>
           <Text style={[pdfStyles.detailItem, pdfStyles.boldText]}>
-            {totalAmount
-              ? amountToWords(totalAmount, language.toLowerCase())
+            {grandTotalAmount
+              ? amountToWords(grandTotalAmount, language.toLowerCase())
               : '0'}{' '}
             {currency.toUpperCase()}{' '}
             {t('cents', {

--- a/client/src/lib/hooks/invoice/use-invoice-form-submission-handler.ts
+++ b/client/src/lib/hooks/invoice/use-invoice-form-submission-handler.ts
@@ -1,13 +1,13 @@
 'use client';
 
-import { SubmitHandler, UseFormSetError } from 'react-hook-form';
+import type { SubmitHandler, UseFormSetError } from 'react-hook-form';
 import { addToast } from '@heroui/react';
 import { useRouter } from 'next/navigation';
 
-import { BankAccount, InvoiceBody, User } from '@invoicetrackr/types';
+import type { BankAccount, InvoiceBody, User } from '@invoicetrackr/types';
 import { addInvoiceAction, updateInvoiceAction } from '@/lib/actions/invoice';
 import { INVOICES_PAGE } from '@/lib/constants/pages';
-import { calculateServiceTotal } from '@/lib/utils';
+import { calculateInvoiceTotals } from '@/lib/utils';
 
 type Props = {
   invoiceData: InvoiceBody | undefined;
@@ -31,10 +31,14 @@ const useInvoiceFormSubmissionHandler = ({
   const onSubmit: SubmitHandler<InvoiceBody> = async (data) => {
     if (!user?.id) return;
 
+    const invoiceTotals = calculateInvoiceTotals(data.services);
+
     const fullData: typeof data = {
       ...data,
       senderSignature: data.senderSignature || '',
-      totalAmount: calculateServiceTotal(data.services).toString(),
+      subtotalAmount: invoiceTotals.subtotalAmount,
+      vatAmount: invoiceTotals.vatAmount,
+      totalAmount: invoiceTotals.totalAmount,
       bankingInformation: bankingInformation || data.bankingInformation
     };
 

--- a/client/src/lib/utils/index.ts
+++ b/client/src/lib/utils/index.ts
@@ -1,4 +1,4 @@
-import { InvoiceServiceBody } from '@invoicetrackr/types';
+import type { InvoiceServiceBody } from '@invoicetrackr/types';
 
 export const capitalize = (str: string) => {
   return str.charAt(0).toUpperCase() + str.slice(1);
@@ -27,8 +27,33 @@ export const getDaysUntilDueDate = (date: string, dueDate: string) => {
 };
 
 export const calculateServiceTotal = (services: Array<InvoiceServiceBody>) =>
-  services.reduce(
-    (acc, currentValue) =>
-      acc + Number(currentValue.amount * Number(currentValue.quantity)),
-    0
+  Number(calculateInvoiceTotals(services).totalAmount);
+
+const toMoney = (amountInCents: number) => (amountInCents / 100).toFixed(2);
+
+export const calculateInvoiceTotals = (
+  services: Array<Pick<InvoiceServiceBody, 'amount' | 'quantity' | 'vatRate'>>
+) => {
+  const totals = services.reduce(
+    (acc, service) => {
+      const subtotalCents = Math.round(
+        Number(service.amount) * Number(service.quantity) * 100
+      );
+      const vatCents = Math.round(
+        subtotalCents * (Number(service.vatRate ?? 0) / 100)
+      );
+
+      return {
+        subtotalCents: acc.subtotalCents + subtotalCents,
+        vatCents: acc.vatCents + vatCents
+      };
+    },
+    { subtotalCents: 0, vatCents: 0 }
   );
+
+  return {
+    subtotalAmount: toMoney(totals.subtotalCents),
+    vatAmount: toMoney(totals.vatCents),
+    totalAmount: toMoney(totals.subtotalCents + totals.vatCents)
+  };
+};

--- a/client/src/lib/utils/pdf.ts
+++ b/client/src/lib/utils/pdf.ts
@@ -114,8 +114,7 @@ export const pdfStyles = StyleSheet.create({
     flexDirection: 'row',
     alignSelf: 'flex-end',
     borderLeftWidth: 1,
-    borderColor: '#bfbfbf',
-    marginBottom: 16
+    borderColor: '#bfbfbf'
   },
   tableColHeader: {
     width: '25%',
@@ -135,13 +134,13 @@ export const pdfStyles = StyleSheet.create({
     borderTopWidth: 0
   },
   tableCol1: {
-    width: '10%'
+    width: '7%'
   },
   tableCol2: {
-    width: '50%'
+    width: '33%'
   },
   tableCol3: {
-    width: '15%'
+    width: '10%'
   },
   tableCol4: {
     width: '10%'
@@ -149,9 +148,15 @@ export const pdfStyles = StyleSheet.create({
   tableCol5: {
     width: '15%'
   },
+  tableCol6: {
+    width: '10%'
+  },
+  tableCol7: {
+    width: '15%'
+  },
   tableCellHeader: {
     margin: 5,
-    fontSize: 12,
+    fontSize: 10,
     fontWeight: 500
   },
   tableCell: {


### PR DESCRIPTION
### Overview

Wires the invoice domain fields from PR #94 into the frontend invoice experience.

Key changes:
- Add per-line VAT/PVM rate input and live VAT-aware invoice totals.
- Send subtotal, VAT total, and grand total from invoice form submissions/previews.
- Update free invoice preview/download flow to use VAT-aware totals.
- Update invoice PDF output with VAT rate, line total, subtotal, VAT total, and grand total.
- Hide the PDF VAT total row when VAT amount is zero.
- Add invoice lifecycle status display to the invoice table.
- Add English and Lithuanian labels for the new VAT/PVM and lifecycle UI.