### PR TITLE
[REK-50] Add server-side invoice numbering

### DIFF
--- a/client/src/api/invoice.ts
+++ b/client/src/api/invoice.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AddInvoiceResponse,
   DeleteInvoiceResponse,
   GetInvoiceResponse,
@@ -6,11 +6,12 @@ import {
   GetInvoicesRevenueResponse,
   GetInvoicesTotalAmountResponse,
   GetLatestInvoicesResponse,
+  GetNextInvoiceNumberResponse,
   SendInvoiceEmailResponse,
   UpdateInvoiceResponse,
   UpdateInvoiceStatusResponse
 } from '@invoicetrackr/types';
-import { InvoiceBody } from '@invoicetrackr/types';
+import type { InvoiceBody } from '@invoicetrackr/types';
 
 import api from './api-instance';
 import { buildFormData } from '@/lib/utils/multipart';
@@ -31,6 +32,14 @@ export const getInvoicesRevenue = async (userId: number) =>
 
 export const getLatestInvoices = async (userId: number) =>
   await api.get<GetLatestInvoicesResponse>(`/api/${userId}/invoices/latest`);
+
+export const getNextInvoiceNumber = async (userId: number, series?: string) => {
+  const query = series ? `?series=${encodeURIComponent(series)}` : '';
+
+  return await api.get<GetNextInvoiceNumberResponse>(
+    `/api/${userId}/invoices/next-number${query}`
+  );
+};
 
 export const addInvoice = async (userId: number, invoiceData: InvoiceBody) => {
   const hasFile = invoiceData.senderSignature instanceof File;

--- a/client/src/app/(user)/invoices/new/page.tsx
+++ b/client/src/app/(user)/invoices/new/page.tsx
@@ -4,7 +4,6 @@ import InvoiceForm from '@/components/invoice/invoice-form';
 import { auth } from '@/auth';
 import { getBankingInformationEntries } from '@/api/banking-information';
 import { getClients } from '@/api/client';
-import { getLatestInvoices } from '@/api/invoice';
 import { getUser } from '@/api/user';
 import { isResponseError } from '@/lib/utils/error';
 
@@ -18,17 +17,14 @@ const AddNewInvoicePage = async () => {
   const userResp = await getUser(numericUserId);
   if (isResponseError(userResp)) unauthorized();
 
-  const [clientsResp, bankingInformationEntriesResp, latestInvoices] =
-    await Promise.all([
-      getClients(numericUserId),
-      getBankingInformationEntries(numericUserId),
-      getLatestInvoices(numericUserId)
-    ]);
+  const [clientsResp, bankingInformationEntriesResp] = await Promise.all([
+    getClients(numericUserId),
+    getBankingInformationEntries(numericUserId)
+  ]);
 
   if (
     isResponseError(clientsResp) ||
-    isResponseError(bankingInformationEntriesResp) ||
-    isResponseError(latestInvoices)
+    isResponseError(bankingInformationEntriesResp)
   )
     throw new Error('Failed to load data');
 
@@ -41,7 +37,6 @@ const AddNewInvoicePage = async () => {
         }
         currency={session.user.currency}
         clients={clientsResp.data.clients}
-        latestInvoiceId={latestInvoices.data.invoices?.at(0)?.invoiceId}
       />
     </section>
   );

--- a/client/src/components/invoice/delete-invoice-modal.tsx
+++ b/client/src/components/invoice/delete-invoice-modal.tsx
@@ -66,7 +66,7 @@ const DeleteInvoiceModal = ({
       <ModalContent>
         <ModalHeader>{t('title')}</ModalHeader>
         <ModalBody>
-          {t('description', { invoiceId: invoiceData.invoiceId })}
+          {t('description', { invoiceId: invoiceData.invoiceId || '' })}
         </ModalBody>
         {renderModalFooter()}
       </ModalContent>

--- a/client/src/components/invoice/invoice-form.tsx
+++ b/client/src/components/invoice/invoice-form.tsx
@@ -14,13 +14,8 @@ import {
   Select,
   SelectItem
 } from '@heroui/react';
-import {
-  Controller,
-  ControllerRenderProps,
-  FormProvider,
-  useForm
-} from 'react-hook-form';
-import { useRef, useState } from 'react';
+import { Controller, FormProvider, useForm } from 'react-hook-form';
+import { useRef, useState, useTransition } from 'react';
 import type { Client } from '@invoicetrackr/types';
 import { useTranslations } from 'next-intl';
 
@@ -32,6 +27,7 @@ import type {
 } from '@invoicetrackr/types';
 import { formatDate, getDateDifferenceInDays } from '@/lib/utils/date';
 import { Currency } from '@/lib/types/currency';
+import { getNextInvoiceNumberAction } from '@/lib/actions/invoice';
 import { statusOptions } from '@/lib/constants/table';
 import useInvoiceFormSubmissionHandler from '@/lib/hooks/invoice/use-invoice-form-submission-handler';
 
@@ -48,7 +44,6 @@ type Props = {
   bankingInformationEntries: Array<BankAccountBody>;
   invoiceData?: InvoiceBody;
   currency: Currency;
-  latestInvoiceId?: string;
 };
 
 const INITIAL_RECEIVER_DATA: Client = {
@@ -67,8 +62,7 @@ const InvoiceForm = ({
   currency,
   invoiceData,
   clients,
-  bankingInformationEntries,
-  latestInvoiceId
+  bankingInformationEntries
 }: Props) => {
   const t = useTranslations('components.invoice_form');
   const methods = useForm<InvoiceBody>({
@@ -99,6 +93,8 @@ const InvoiceForm = ({
   const [senderSignature, setSenderSignature] = useState<
     string | File | undefined
   >(invoiceData?.senderSignature);
+  const [isNextInvoiceNumberPending, startNextInvoiceNumberTransition] =
+    useTransition();
 
   const { onSubmit, redirectToInvoicesPage } = useInvoiceFormSubmissionHandler({
     invoiceData,
@@ -146,17 +142,18 @@ const InvoiceForm = ({
     clearErrors('senderSignature');
   };
 
-  const handleNextInvoiceIdSelect = (
-    field: ControllerRenderProps<InvoiceBody, 'invoiceId'>
-  ) => {
-    if (!latestInvoiceId) return;
+  const handleNextInvoiceIdSelect = () => {
+    startNextInvoiceNumberTransition(async () => {
+      const response = await getNextInvoiceNumberAction({
+        userId: user.id || 0
+      });
 
-    const latestInvoiceIdNumber = Number(latestInvoiceId.slice(3));
-    const newInvoiceId = latestInvoiceId
-      .slice(0, 3)
-      .concat((latestInvoiceIdNumber + 1).toString().padStart(3, '0'));
+      if (!response.ok) return;
 
-    field.onChange(newInvoiceId);
+      setValue('invoiceId', response.invoiceId, { shouldDirty: true });
+      setValue('invoiceSeries', response.series, { shouldDirty: true });
+      clearErrors('invoiceId');
+    });
   };
 
   const renderSenderAndReceiverFields = () => (
@@ -512,25 +509,32 @@ const InvoiceForm = ({
                   render={({ field }) => (
                     <Input
                       {...field}
+                      onChange={(event) => {
+                        setValue('invoiceSeries', undefined, {
+                          shouldDirty: true
+                        });
+                        field.onChange(event);
+                      }}
                       aria-label={t('a11y.invoice_id_label')}
                       label={t('labels.invoice_id')}
                       placeholder={t('placeholders.invoice_id')}
                       isInvalid={!!errors.invoiceId}
                       errorMessage={errors.invoiceId?.message}
                       endContent={
-                        latestInvoiceId && (
-                          <Button
-                            size="sm"
-                            variant="faded"
-                            className="px-7"
-                            startContent={
+                        <Button
+                          size="sm"
+                          variant="faded"
+                          className="px-7"
+                          isLoading={isNextInvoiceNumberPending}
+                          startContent={
+                            !isNextInvoiceNumberPending && (
                               <SparklesIcon className="min-h-4 min-w-4" />
-                            }
-                            onPress={() => handleNextInvoiceIdSelect(field)}
-                          >
-                            {t('buttons.use_next')}
-                          </Button>
-                        )
+                            )
+                          }
+                          onPress={handleNextInvoiceIdSelect}
+                        >
+                          {t('buttons.use_next')}
+                        </Button>
                       }
                     />
                   )}

--- a/client/src/components/invoice/invoice-table.tsx
+++ b/client/src/components/invoice/invoice-table.tsx
@@ -136,7 +136,7 @@ const InvoiceTable = ({
 
     if (hasSearchFilter) {
       filteredInvoices = filteredInvoices.filter((invoice) =>
-        invoice.invoiceId
+        (invoice.invoiceId || '')
           .toString()
           .toLowerCase()
           .includes(filterValue.toLowerCase())

--- a/client/src/components/invoice/send-invoice-email-modal.tsx
+++ b/client/src/components/invoice/send-invoice-email-modal.tsx
@@ -70,7 +70,7 @@ export default function SendInvoiceEmailModal({
         id: Number(invoice.id),
         userId,
         blob,
-        invoiceId: invoice.invoiceId,
+        invoiceId: invoice.invoiceId || '',
         recipientEmail: data.recipientEmail,
         subject: data.subject,
         message: data.message
@@ -106,7 +106,7 @@ export default function SendInvoiceEmailModal({
               encType="multipart/form-data"
             >
               <ModalHeader>
-                {t('modal_title', { invoiceId: invoice.invoiceId })}
+                {t('modal_title', { invoiceId: invoice.invoiceId || '' })}
               </ModalHeader>
               <ModalBody className="w-full">
                 <Input

--- a/client/src/lib/actions/invoice.ts
+++ b/client/src/lib/actions/invoice.ts
@@ -3,16 +3,41 @@
 import {
   addInvoice,
   deleteInvoice,
+  getNextInvoiceNumber,
   updateInvoice,
   updateInvoiceStatus
 } from '@/api/invoice';
-import { InvoiceBody } from '@invoicetrackr/types';
+import type { InvoiceBody } from '@invoicetrackr/types';
 import { revalidatePath } from 'next/cache';
 
 import { EDIT_INVOICE_PAGE, INVOICES_PAGE } from '../constants/pages';
-import { ActionResponseModel } from '../types/action';
+import type { ActionResponseModel } from '../types/action';
 import { isResponseError } from '../utils/error';
 import { mapValidationErrors } from '../utils/validation';
+
+export const getNextInvoiceNumberAction = async ({
+  userId,
+  series
+}: {
+  userId: number;
+  series?: string;
+}) => {
+  const response = await getNextInvoiceNumber(userId, series);
+
+  if (isResponseError(response)) {
+    return {
+      ok: false,
+      message: response.data.message
+    };
+  }
+
+  return {
+    ok: true,
+    invoiceId: response.data.invoiceId,
+    series: response.data.series,
+    nextNumber: response.data.nextNumber
+  };
+};
 
 export const addInvoiceAction = async ({
   userId,

--- a/client/src/lib/utils/index.ts
+++ b/client/src/lib/utils/index.ts
@@ -5,13 +5,17 @@ export const capitalize = (str: string) => {
 };
 
 export const validateInvoiceId = (invoiceId: string) => {
-  const regex = /^[A-Za-z]{3}[1-9][0-9]*$/;
+  const regex = /^[A-Za-z]{2,8}[1-9][0-9]*$/;
   return regex.test(invoiceId);
 };
 
 export const splitInvoiceId = (invoiceId: string) => {
-  const series = invoiceId?.slice(0, 3);
-  const number = invoiceId?.slice(3);
+  const match = invoiceId?.match(/^([A-Za-z]{2,8})([0-9]+)$/);
+
+  if (!match) return [invoiceId || '', ''];
+
+  const series = match[1];
+  const number = match[2];
 
   return [series, number];
 };

--- a/server/drizzle/0017_shallow_veda.sql
+++ b/server/drizzle/0017_shallow_veda.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "invoice_number_sequences" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"series" varchar(8) NOT NULL,
+	"next_number" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT "invoice_number_sequences_user_series_key" UNIQUE("user_id","series")
+);
+--> statement-breakpoint
+ALTER TABLE "invoice_number_sequences" ADD CONSTRAINT "fk_invoice_number_sequences_user_id" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+INSERT INTO "invoice_number_sequences" ("user_id", "series", "next_number")
+SELECT
+	"user_id",
+	UPPER(SUBSTRING("invoice_id" FROM '^([A-Za-z]{2,8})[0-9]{1,9}$')) AS "series",
+	MAX((SUBSTRING("invoice_id" FROM '^[A-Za-z]{2,8}([0-9]{1,9})$'))::integer) + 1 AS "next_number"
+FROM "invoices"
+WHERE "invoice_id" ~ '^[A-Za-z]{2,8}[0-9]{1,9}$'
+GROUP BY "user_id", "series";
+--> statement-breakpoint
+ALTER TABLE "invoices" ADD CONSTRAINT "invoices_user_invoice_id_key" UNIQUE("user_id","invoice_id");

--- a/server/drizzle/meta/0017_snapshot.json
+++ b/server/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,988 @@
+{
+  "id": "d6f1d0c2-2c00-4a12-ad61-a053d879088e",
+  "prevId": "7fc46933-2d4e-4336-b47e-537a49e1531d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.banking_information": {
+      "name": "banking_information",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banking_information_user_id_fkey": {
+          "name": "banking_information_user_id_fkey",
+          "tableFrom": "banking_information",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_clients_user_id": {
+          "name": "fk_clients_user_id",
+          "tableFrom": "clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_banking_information": {
+      "name": "invoice_banking_information",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountName": {
+          "name": "accountName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountNumber": {
+          "name": "accountNumber",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bankCode": {
+          "name": "bankCode",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_banking_information_invoice_id": {
+          "name": "fk_invoice_banking_information_invoice_id",
+          "tableFrom": "invoice_banking_information",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_number_sequences": {
+      "name": "invoice_number_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series": {
+          "name": "series",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_number_sequences_user_id": {
+          "name": "fk_invoice_number_sequences_user_id",
+          "tableFrom": "invoice_number_sequences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_number_sequences_user_series_key": {
+          "name": "invoice_number_sequences_user_series_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_receivers": {
+      "name": "invoice_receivers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_receivers_invoice_id": {
+          "name": "fk_invoice_receivers_invoice_id",
+          "tableFrom": "invoice_receivers",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_senders": {
+      "name": "invoice_senders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_senders_invoice_id": {
+          "name": "fk_invoice_senders_invoice_id",
+          "tableFrom": "invoice_senders",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_services": {
+      "name": "invoice_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_rate": {
+          "name": "vat_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_services_invoice_id": {
+          "name": "fk_invoice_services_invoice_id",
+          "tableFrom": "invoice_services",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "vat_amount": {
+          "name": "vat_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sender_signature": {
+          "name": "sender_signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoices_invoice_senders": {
+          "name": "fk_invoices_invoice_senders",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_senders",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_invoices_invoice_receivers": {
+          "name": "fk_invoices_invoice_receivers",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_receivers",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_invoices_invoice_banking_information": {
+          "name": "fk_invoices_invoice_banking_information",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_banking_information",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_user_invoice_id_key": {
+          "name": "invoices_user_invoice_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "invoice_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "(status)::text = ANY ((ARRAY['paid'::character varying, 'pending'::character varying, 'canceled'::character varying])::text[])"
+        },
+        "invoices_lifecycle_status_check": {
+          "name": "invoices_lifecycle_status_check",
+          "value": "(lifecycle_status)::text = ANY ((ARRAY['draft'::character varying, 'issued'::character varying, 'voided'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_unique": {
+          "name": "password_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_accounts": {
+      "name": "stripe_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_accounts_user_id_users_id_fk": {
+          "name": "stripe_accounts_user_id_users_id_fk",
+          "tableFrom": "stripe_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_accounts_stripe_customer_id_unique": {
+          "name": "stripe_accounts_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "stripe_accounts_stripe_subscription_id_unique": {
+          "name": "stripe_accounts_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_bank_account_id": {
+          "name": "selected_bank_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_picture_url": {
+          "name": "profile_picture_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_invoice_language": {
+          "name": "preferred_invoice_language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_selected_bank_account": {
+          "name": "fk_selected_bank_account",
+          "tableFrom": "users",
+          "tableTo": "banking_information",
+          "columnsFrom": [
+            "selected_bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1779991377000,
       "tag": "0016_invoice_domain_foundation",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1780148979030,
+      "tag": "0017_shallow_veda",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/controllers/__tests__/invoice.ts
+++ b/server/src/controllers/__tests__/invoice.ts
@@ -137,7 +137,7 @@ describe('Invoice Controller', () => {
         method: 'POST',
         url: `/api/${testUserId}/invoices`,
         payload: {
-          invoiceId: 'INV-003',
+          invoiceId: 'INV003',
           clientId: 1,
           invoiceDate: '2024-01-01',
           dueDate: '2024-02-01',
@@ -180,7 +180,7 @@ describe('Invoice Controller', () => {
         method: 'POST',
         url: `/api/${testUserId}/invoices`,
         payload: {
-          invoiceId: 'INV-001',
+          invoiceId: 'INV001',
           clientId: 1,
           invoiceDate: '2024-01-01',
           dueDate: '2024-02-01',
@@ -217,7 +217,7 @@ describe('Invoice Controller', () => {
         url: `/api/${testUserId}/invoices/${mockInvoice.id}`,
         payload: {
           id: mockInvoice.id,
-          invoiceId: 'INV-001',
+          invoiceId: 'INV001',
           totalAmount: 1500
         }
       });

--- a/server/src/controllers/invoice.ts
+++ b/server/src/controllers/invoice.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { UploadApiResponse, v2 as cloudinary } from 'cloudinary';
-import { InvoiceBody } from '@invoicetrackr/types';
+import type { InvoiceBody } from '@invoicetrackr/types';
 import { InvoiceEmail } from '@invoicetrackr/emails';
 import { MultipartFile } from '@fastify/multipart';
 import { useI18n } from 'fastify-i18n';
@@ -19,6 +19,7 @@ import {
   getInvoicesRevenueFromDb,
   getInvoicesTotalAmountFromDb,
   getLatestInvoicesFromDb,
+  getNextInvoiceNumberFromDb,
   insertInvoiceInDb,
   updateInvoiceInDb,
   updateInvoiceStatusInDb
@@ -51,6 +52,22 @@ export const getInvoice = async (
   reply.status(200).send({ invoice });
 };
 
+export const getNextInvoiceNumber = async (
+  req: FastifyRequest<{
+    Params: { userId: string };
+    Querystring: { series?: string };
+  }>,
+  reply: FastifyReply
+) => {
+  const userId = Number(req.params.userId);
+  const nextInvoiceNumber = await getNextInvoiceNumberFromDb(
+    userId,
+    req.query.series
+  );
+
+  reply.status(200).send(nextInvoiceNumber);
+};
+
 export const postInvoice = async (
   req: FastifyRequest<{
     Params: { userId: string };
@@ -76,10 +93,10 @@ export const postInvoice = async (
       throw new BadRequestError(i18n.t('error.user.unableToUploadSignature'));
   }
 
-  const foundInvoice = await findInvoiceByInvoiceId(
-    userId,
-    invoiceData.invoiceId
-  );
+  const foundInvoice =
+    invoiceData.invoiceId && !invoiceData.invoiceSeries
+      ? await findInvoiceByInvoiceId(userId, invoiceData.invoiceId)
+      : null;
 
   if (foundInvoice)
     throw new AlreadyExistsError(i18n.t('error.invoice.alreadyExists'));
@@ -119,6 +136,19 @@ export const updateInvoice = async (
   const foundInvoice = await findInvoiceById(userId, Number(invoiceData.id));
 
   if (!foundInvoice) throw new NotFoundError(i18n.t('error.invoice.notFound'));
+
+  if (invoiceData.invoiceId) {
+    const existingInvoiceWithNumber = await findInvoiceByInvoiceId(
+      userId,
+      invoiceData.invoiceId
+    );
+
+    if (
+      existingInvoiceWithNumber &&
+      existingInvoiceWithNumber.id !== Number(invoiceData.id)
+    )
+      throw new AlreadyExistsError(i18n.t('error.invoice.alreadyExists'));
+  }
 
   let uploadedSignature: UploadApiResponse | undefined;
 
@@ -285,7 +315,7 @@ export const sendInvoiceEmail = async (
     : undefined;
 
   const htmlContent = InvoiceEmail({
-    invoiceNumber: invoice.invoiceId,
+    invoiceNumber: invoice.invoiceId || '',
     amount: `${invoice.totalAmount} ${user.currency}`,
     dueDate: invoice.dueDate,
     senderName: user.name || user.email,

--- a/server/src/database/invoice.ts
+++ b/server/src/database/invoice.ts
@@ -1,9 +1,10 @@
 import { and, desc, eq, gte, inArray, sql } from 'drizzle-orm';
-import { InvoiceBody } from '@invoicetrackr/types';
+import type { InvoiceBody } from '@invoicetrackr/types';
 
 import {
   bankingInformationTable,
   invoiceBankingInformationTable,
+  invoiceNumberSequencesTable,
   invoiceReceiversTable,
   invoiceSendersTable,
   invoiceServicesTable,
@@ -12,6 +13,9 @@ import {
 import { calculateInvoiceTotals } from '../utils/invoice';
 import { db } from './db';
 import { jsonAgg } from '../utils/json';
+
+const DEFAULT_INVOICE_SERIES = 'SF';
+const INVOICE_NUMBER_PADDING = 3;
 
 export type InvoiceFromDb = Omit<
   InvoiceBody,
@@ -26,6 +30,138 @@ export type InvoiceFromDb = Omit<
   services: Array<
     Omit<typeof invoiceServicesTable.$inferSelect, 'invoiceId'>
   > | null;
+};
+
+const normalizeInvoiceSeries = (series?: string | null) =>
+  (series || DEFAULT_INVOICE_SERIES).trim().toUpperCase();
+
+const formatInvoiceNumber = (series: string, number: number) =>
+  `${series}${String(number).padStart(INVOICE_NUMBER_PADDING, '0')}`;
+
+const parseInvoiceNumber = (invoiceId: string) => {
+  const match = invoiceId.trim().toUpperCase().match(/^([A-Z]{2,8})(\d{1,9})$/);
+
+  if (!match) return null;
+
+  return {
+    series: match[1],
+    number: Number(match[2])
+  };
+};
+
+type InvoiceTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+const getInvoiceSeriesForNextNumber = async (
+  query: InvoiceTransaction | typeof db,
+  userId: number,
+  requestedSeries?: string
+) => {
+  if (requestedSeries) return normalizeInvoiceSeries(requestedSeries);
+
+  const latestInvoices = await query
+    .select({ invoiceId: invoicesTable.invoiceId })
+    .from(invoicesTable)
+    .where(eq(invoicesTable.userId, userId))
+    .orderBy(desc(invoicesTable.id))
+    .limit(1);
+  const latestInvoiceSeries = latestInvoices.at(0)?.invoiceId
+    ? parseInvoiceNumber(latestInvoices[0].invoiceId)?.series
+    : null;
+
+  return latestInvoiceSeries || DEFAULT_INVOICE_SERIES;
+};
+
+export const getNextInvoiceNumberFromDb = async (
+  userId: number,
+  requestedSeries?: string
+) => {
+  const series = await getInvoiceSeriesForNextNumber(
+    db,
+    userId,
+    requestedSeries
+  );
+  const sequences = await db
+    .select({
+      nextNumber: invoiceNumberSequencesTable.nextNumber
+    })
+    .from(invoiceNumberSequencesTable)
+    .where(
+      and(
+        eq(invoiceNumberSequencesTable.userId, userId),
+        eq(invoiceNumberSequencesTable.series, series)
+      )
+    );
+  const nextNumber = sequences.at(0)?.nextNumber || 1;
+
+  return {
+    invoiceId: formatInvoiceNumber(series, nextNumber),
+    series,
+    nextNumber
+  };
+};
+
+const reserveNextInvoiceNumber = async (
+  tx: InvoiceTransaction,
+  userId: number,
+  requestedSeries?: string
+) => {
+  const series = await getInvoiceSeriesForNextNumber(
+    tx,
+    userId,
+    requestedSeries
+  );
+  const sequence = await tx
+    .insert(invoiceNumberSequencesTable)
+    .values({
+      userId,
+      series,
+      nextNumber: 2
+    })
+    .onConflictDoUpdate({
+      target: [
+        invoiceNumberSequencesTable.userId,
+        invoiceNumberSequencesTable.series
+      ],
+      set: {
+        nextNumber: sql`${invoiceNumberSequencesTable.nextNumber} + 1`,
+        updatedAt: sql`CURRENT_TIMESTAMP`
+      }
+    })
+    .returning({ nextNumber: invoiceNumberSequencesTable.nextNumber });
+
+  const reservedNumber = Number(sequence.at(0)?.nextNumber || 2) - 1;
+
+  return formatInvoiceNumber(series, reservedNumber);
+};
+
+const advanceInvoiceNumberSequence = async (
+  tx: InvoiceTransaction,
+  userId: number,
+  invoiceId: string
+) => {
+  const parsedInvoiceNumber = parseInvoiceNumber(invoiceId);
+
+  if (!parsedInvoiceNumber) return;
+
+  const nextNumber = parsedInvoiceNumber.number + 1;
+
+  await tx
+    .insert(invoiceNumberSequencesTable)
+    .values({
+      userId,
+      series: parsedInvoiceNumber.series,
+      nextNumber
+    })
+    .onConflictDoUpdate({
+      target: [
+        invoiceNumberSequencesTable.userId,
+        invoiceNumberSequencesTable.series
+      ],
+      set: {
+        nextNumber: sql`GREATEST(${invoiceNumberSequencesTable.nextNumber}, ${nextNumber})`,
+        updatedAt: sql`CURRENT_TIMESTAMP`
+      }
+    });
 };
 
 export const findInvoiceById = async (userId: number, id: number) => {
@@ -139,7 +275,7 @@ export const getInvoicesFromDb = async (
 export const getInvoiceFromDb = async (
   userId: number,
   id: number,
-  transaction?: Parameters<Parameters<typeof db.transaction>[0]>[0]
+  transaction?: InvoiceTransaction
 ): Promise<InvoiceFromDb | undefined> => {
   const invoices = await (transaction ? transaction : db)
     .select({
@@ -226,6 +362,10 @@ export const insertInvoiceInDb = async (
 ): Promise<InvoiceFromDb | null> => {
   const invoice = await db.transaction(async (tx) => {
     const totals = calculateInvoiceTotals(invoiceData.services);
+    const invoiceId =
+      invoiceData.invoiceSeries || !invoiceData.invoiceId
+        ? await reserveNextInvoiceNumber(tx, userId, invoiceData.invoiceSeries)
+        : invoiceData.invoiceId;
 
     // Invoice insert
     const invoices = await tx
@@ -233,7 +373,7 @@ export const insertInvoiceInDb = async (
       .values({
         userId,
         date: invoiceData.date,
-        invoiceId: invoiceData.invoiceId,
+        invoiceId,
         subtotalAmount: totals.subtotalAmount,
         vatAmount: totals.vatAmount,
         totalAmount: totals.totalAmount,
@@ -247,6 +387,10 @@ export const insertInvoiceInDb = async (
     const insertedInvoiceId = invoices.at(0)?.id;
 
     if (!insertedInvoiceId) throw new Error('Failed to insert invoice');
+
+    if (!invoiceData.invoiceSeries && invoiceData.invoiceId) {
+      await advanceInvoiceNumberSequence(tx, userId, invoiceData.invoiceId);
+    }
 
     // Invoice sender insert
     const senders = await tx
@@ -471,6 +615,10 @@ export const updateInvoiceInDb = async (
       .returning({ id: invoicesTable.id });
 
     if (!invoices[0]) return null;
+
+    if (invoiceData.invoiceId) {
+      await advanceInvoiceNumberSequence(tx, userId, invoiceData.invoiceId);
+    }
 
     // Handle services update
     const existingServices = await tx

--- a/server/src/database/schema.ts
+++ b/server/src/database/schema.ts
@@ -97,6 +97,36 @@ export const invoicesTable = pgTable(
     check(
       'invoices_lifecycle_status_check',
       sql`(lifecycle_status)::text = ANY ((ARRAY['draft'::character varying, 'issued'::character varying, 'voided'::character varying])::text[])`
+    ),
+    unique('invoices_user_invoice_id_key').on(table.userId, table.invoiceId)
+  ]
+);
+
+export const invoiceNumberSequencesTable = pgTable(
+  'invoice_number_sequences',
+  {
+    id: serial().primaryKey().notNull(),
+    userId: integer('user_id').notNull(),
+    series: varchar({ length: 8 }).notNull(),
+    nextNumber: integer('next_number').default(1).notNull(),
+    createdAt: timestamp('created_at', {
+      withTimezone: true,
+      mode: 'string'
+    }).default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: timestamp('updated_at', {
+      withTimezone: true,
+      mode: 'string'
+    }).default(sql`CURRENT_TIMESTAMP`)
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [usersTable.id],
+      name: 'fk_invoice_number_sequences_user_id'
+    }).onDelete('cascade'),
+    unique('invoice_number_sequences_user_series_key').on(
+      table.userId,
+      table.series
     )
   ]
 );
@@ -280,6 +310,11 @@ export const stripeAccountsTable = pgTable('stripe_accounts', {
 
 export type InsertInvoice = typeof invoicesTable.$inferInsert;
 export type SelectInvoice = typeof invoicesTable.$inferSelect;
+
+export type InsertInvoiceNumberSequence =
+  typeof invoiceNumberSequencesTable.$inferInsert;
+export type SelectInvoiceNumberSequence =
+  typeof invoiceNumberSequencesTable.$inferSelect;
 
 export type InsertBankingInformation =
   typeof bankingInformationTable.$inferInsert;

--- a/server/src/locales/en.ts
+++ b/server/src/locales/en.ts
@@ -44,7 +44,8 @@ export default {
       mismatch: 'Passwords do not match'
     },
     invoice: {
-      invoiceId: 'Required to match format "ABC123"',
+      invoiceId: 'Required to match format "ABC123" or "SF001"',
+      invoiceSeries: 'Invoice series must be 2-8 letters',
       date: 'Valid date is required',
       dueDate: 'Valid date is required',
       dueDateAfterDate: 'Due date must be after invoice date',

--- a/server/src/locales/lt.ts
+++ b/server/src/locales/lt.ts
@@ -45,7 +45,8 @@ export default {
       mismatch: 'Slaptažodžiai nesutampa'
     },
     invoice: {
-      invoiceId: 'Turi atitikti formatą "ABC123"',
+      invoiceId: 'Turi atitikti formatą "ABC123" arba "SF001"',
+      invoiceSeries: 'Sąskaitos serija turi būti 2-8 raidės',
       date: 'Reikalinga tinkama data',
       dueDate: 'Reikalinga tinkama data',
       dueDateAfterDate: 'Terminas neturi būti ankstesnis už sąskaitos datą',

--- a/server/src/options/invoice.ts
+++ b/server/src/options/invoice.ts
@@ -4,7 +4,9 @@ import {
   getInvoicesRevenueResponseSchema,
   getInvoicesTotalAmountResponseSchema,
   getLatestInvoicesResponseSchema,
+  getNextInvoiceNumberResponseSchema,
   invoiceBodySchema,
+  invoiceNumberSeriesSchema,
   messageResponseSchema,
   postInvoiceResponseSchema,
   updateInvoiceResponseSchema
@@ -19,6 +21,7 @@ import {
   getInvoicesRevenue,
   getInvoicesTotalAmount,
   getLatestInvoices,
+  getNextInvoiceNumber,
   postInvoice,
   sendInvoiceEmail,
   updateInvoice,
@@ -45,6 +48,19 @@ export const getInvoiceOptions: RouteShorthandOptionsWithHandler = {
   },
   preHandler: authMiddleware,
   handler: getInvoice
+};
+
+export const getNextInvoiceNumberOptions: RouteShorthandOptionsWithHandler = {
+  schema: {
+    querystring: z.object({
+      series: invoiceNumberSeriesSchema.optional()
+    }),
+    response: {
+      200: getNextInvoiceNumberResponseSchema
+    }
+  },
+  preHandler: authMiddleware,
+  handler: getNextInvoiceNumber
 };
 
 export const postInvoiceOptions: RouteShorthandOptionsWithHandler = {

--- a/server/src/routes/invoice.ts
+++ b/server/src/routes/invoice.ts
@@ -11,6 +11,7 @@ import {
   getInvoicesRevenueOptions,
   getInvoicesTotalAmountOptions,
   getLatestInvoicesOptions,
+  getNextInvoiceNumberOptions,
   postInvoiceOptions,
   sendInvoiceEmailOptions,
   updateInvoiceOptions,
@@ -23,6 +24,8 @@ const invoiceRoutes = (
   done: DoneFuncWithErrOrRes
 ) => {
   fastify.get('/api/:userId/invoices', getInvoicesOptions);
+
+  fastify.get('/api/:userId/invoices/next-number', getNextInvoiceNumberOptions);
 
   fastify.get('/api/:userId/invoices/:id', getInvoiceOptions);
 

--- a/server/src/test/factories/invoice.ts
+++ b/server/src/test/factories/invoice.ts
@@ -22,7 +22,7 @@ export const invoiceFactory = Factory.define<InvoiceBody>(({ sequence }) => ({
   dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
     .toISOString()
     .split('T')[0],
-  invoiceId: `INV-${sequence}`,
+  invoiceId: `INV${String(sequence).padStart(3, '0')}`,
   senderSignature: `signature${sequence}.png`,
   issuedAt: null,
   paidAt: null,
@@ -46,7 +46,7 @@ export const invoiceFromDbFactory = Factory.define<InvoiceFromDb>(
     dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
       .toISOString()
       .split('T')[0],
-    invoiceId: `INV-${sequence}`,
+    invoiceId: `INV${String(sequence).padStart(3, '0')}`,
     senderSignature: `signature${sequence}.png`,
     issuedAt: null,
     paidAt: null,

--- a/shared/types/src/invoice.ts
+++ b/shared/types/src/invoice.ts
@@ -24,6 +24,18 @@ export const invoicePartyTypeSchema = z.enum(['sender', 'receiver'], {
   message: 'validation.invoice.partyType'
 });
 
+export const invoiceNumberSeriesSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .regex(/^[A-Z]{2,8}$/, 'validation.invoice.invoiceSeries');
+
+export const invoiceNumberSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .regex(/^[A-Z]{2,8}[0-9]{1,9}$/, 'validation.invoice.invoiceId');
+
 export const invoiceServiceBodySchema = z.object({
   id: z.coerce.number().optional(),
   description: z
@@ -83,12 +95,8 @@ export const invoiceReceiverBodySchema = z.object(
 export const invoiceBodySchema = z
   .object({
     id: z.coerce.number().optional(),
-    invoiceId: z
-      .string()
-      .regex(
-        /^[A-Za-z]{3}(0[0-9]{2}|[1-9][0-9]{2}|[1-9]0{2})$/,
-        'validation.invoice.invoiceId'
-      ),
+    invoiceId: invoiceNumberSchema.optional().or(z.literal('')),
+    invoiceSeries: invoiceNumberSeriesSchema.optional(),
     date: z.iso.date('validation.invoice.date'),
     dueDate: z.iso.date('validation.invoice.dueDate'),
     sender: invoiceSenderBodySchema,
@@ -118,6 +126,7 @@ export const invoiceBodySchema = z
 
 // Types
 export type InvoiceStatus = z.infer<typeof invoiceStatusSchema>;
+export type InvoiceNumberSeries = z.infer<typeof invoiceNumberSeriesSchema>;
 export type InvoiceLifecycleStatus = z.infer<
   typeof invoiceLifecycleStatusSchema
 >;

--- a/shared/types/src/response.ts
+++ b/shared/types/src/response.ts
@@ -84,6 +84,12 @@ export const updateInvoiceResponseSchema = z.object({
   message: z.string()
 });
 
+export const getNextInvoiceNumberResponseSchema = z.object({
+  invoiceId: z.string(),
+  series: z.string(),
+  nextNumber: z.number()
+});
+
 export const getInvoicesTotalAmountResponseSchema = z.object({
   invoices: z.array(
     z.object({
@@ -179,6 +185,9 @@ export type GetInvoicesResponse = z.infer<typeof getInvoicesResponseSchema>;
 export type GetInvoiceResponse = z.infer<typeof getInvoiceResponseSchema>;
 export type PostInvoiceResponse = z.infer<typeof postInvoiceResponseSchema>;
 export type UpdateInvoiceResponse = z.infer<typeof updateInvoiceResponseSchema>;
+export type GetNextInvoiceNumberResponse = z.infer<
+  typeof getNextInvoiceNumberResponseSchema
+>;
 export type GetInvoicesTotalAmountResponse = z.infer<
   typeof getInvoicesTotalAmountResponseSchema
 >;


### PR DESCRIPTION
### Overview
Adds server-owned invoice numbering so new invoices no longer depend on client-side latest-invoice slicing.

Key changes:
- Add invoice number sequence storage per user and series.
- Generate next invoice numbers server-side when invoice ID is blank.
- Add next-number preview endpoint for the invoice form.
- Update “Use Next” to call the server-backed numbering flow.
- Reuse the latest invoice series when no series is explicitly requested.
- Keep manual invoice number overrides and advance matching series sequences.
- Add unique invoice number enforcement per user.
- Add migration and seed sequence state from existing invoice numbers.
