### PR TITLE
[REK-68] Invoice signing link controls

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -398,7 +398,8 @@
     "signature_required": "Add a signature before signing.",
     "sign_button": "Sign invoice",
     "already_signed": "Invoice signed",
-    "download_pdf": "Download PDF"
+    "download_pdf": "Download PDF",
+    "link_unavailable": "Invoice link unavailable"
   },
   "clients": {
     "page_title": "Clients",
@@ -690,6 +691,13 @@
       "amount": "Amount",
       "date": "Date",
       "signing_link_note": "This email will include a secure signing link for the recipient.",
+      "active_signing_recipient": "Active signing link sent to {email}.",
+      "signing_link_expires": "Link expires on {date}.",
+      "signing_link_revoked": "This link has been revoked.",
+      "replacement_link_note": "Sending will invalidate the previous link and create a fresh one.",
+      "revoke_signing_link": "Revoke link",
+      "regenerate_signing_link": "Generate fresh link",
+      "replace_link_and_send": "Replace link and send",
       "cancel": "Cancel",
       "send": "Send"
     },

--- a/client/messages/lt.json
+++ b/client/messages/lt.json
@@ -398,7 +398,8 @@
     "signature_required": "Pridėkite parašą prieš pasirašydami.",
     "sign_button": "Pasirašyti sąskaitą",
     "already_signed": "Sąskaita pasirašyta",
-    "download_pdf": "Atsisiųsti PDF"
+    "download_pdf": "Atsisiųsti PDF",
+    "link_unavailable": "Sąskaitos nuoroda nepasiekiama"
   },
   "clients": {
     "page_title": "Klientai",
@@ -690,6 +691,13 @@
       "amount": "Suma",
       "date": "Data",
       "signing_link_note": "Šiame laiške bus saugi pasirašymo nuoroda gavėjui.",
+      "active_signing_recipient": "Aktyvi pasirašymo nuoroda išsiųsta adresu {email}.",
+      "signing_link_expires": "Nuoroda galioja iki {date}.",
+      "signing_link_revoked": "Ši nuoroda buvo atšaukta.",
+      "replacement_link_note": "Siunčiant ankstesnė nuoroda bus panaikinta ir sukurta nauja.",
+      "revoke_signing_link": "Atšaukti nuorodą",
+      "regenerate_signing_link": "Generuoti naują nuorodą",
+      "replace_link_and_send": "Pakeisti nuorodą ir siųsti",
       "cancel": "Atšaukti",
       "send": "Siųsti"
     },

--- a/client/src/api/invoice.ts
+++ b/client/src/api/invoice.ts
@@ -124,6 +124,28 @@ export const signPublicInvoice = async ({
   );
 };
 
+export const revokeInvoiceSigningLink = async (
+  userId: number,
+  invoiceId: number
+) =>
+  await api.post<SendInvoiceEmailResponse>(
+    `/api/${userId}/invoices/${invoiceId}/signing-link/revoke`
+  );
+
+export const regenerateInvoiceSigningLink = async ({
+  userId,
+  invoiceId,
+  recipientEmail
+}: {
+  userId: number;
+  invoiceId: number;
+  recipientEmail: string;
+}) =>
+  await api.post<SendInvoiceEmailResponse>(
+    `/api/${userId}/invoices/${invoiceId}/signing-link/regenerate`,
+    { recipientEmail }
+  );
+
 export const sendInvoiceEmail = async ({
   id,
   userId,

--- a/client/src/app/invoices/sign/[token]/page.tsx
+++ b/client/src/app/invoices/sign/[token]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
 
 import { getPublicInvoiceSigning } from '@/api/invoice';
 import { isResponseError } from '@/lib/utils/error';
@@ -13,9 +13,20 @@ export default async function InvoiceSigningPage({
   params: Params;
 }) {
   const { token } = await params;
+  const t = await getTranslations('invoice_signing');
   const response = await getPublicInvoiceSigning(token);
 
-  if (isResponseError(response)) notFound();
+  if (isResponseError(response))
+    return (
+      <main className="mx-auto flex min-h-[60vh] max-w-xl items-center px-4 py-12">
+        <section className="border-default-200 w-full rounded-lg border bg-white p-6 shadow-sm dark:bg-black">
+          <h1 className="text-xl font-semibold">{t('link_unavailable')}</h1>
+          <p className="text-default-500 mt-2 text-sm">
+            {response.data.message}
+          </p>
+        </section>
+      </main>
+    );
 
   return <InvoiceSigningPageContent signing={response.data.signing} />;
 }

--- a/client/src/components/invoice/send-invoice-email-modal.tsx
+++ b/client/src/components/invoice/send-invoice-email-modal.tsx
@@ -13,9 +13,12 @@ import {
   Textarea,
   addToast
 } from '@heroui/react';
+import {
+  InformationCircleIcon,
+  PaperAirplaneIcon
+} from '@heroicons/react/24/outline';
 import { JSX, useTransition } from 'react';
 import { BlobProvider } from '@react-pdf/renderer';
-import { PaperAirplaneIcon } from '@heroicons/react/24/outline';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -154,6 +157,35 @@ export default function SendInvoiceEmailModal({
                 {t('modal_title', { invoiceId: invoice.invoiceId || '' })}
               </ModalHeader>
               <ModalBody className="w-full">
+                <div className="border-secondary-200 bg-secondary-50 dark:bg-secondary-900/20 flex gap-3 rounded-lg border p-3">
+                  <InformationCircleIcon className="text-secondary-500 mt-0.5 h-5 w-5 shrink-0" />
+                  <div className="flex flex-col gap-1 text-sm">
+                    <p>{t('signing_link_note')}</p>
+                    {invoice.recipientSigningEmail && (
+                      <p className="text-default-500">
+                        {t('active_signing_recipient', {
+                          email: invoice.recipientSigningEmail
+                        })}
+                      </p>
+                    )}
+                    {invoice.recipientSigningRevokedAt ? (
+                      <p className="text-danger">{t('signing_link_revoked')}</p>
+                    ) : invoice.recipientSigningExpiresAt ? (
+                      <p className="text-default-500">
+                        {t('signing_link_expires', {
+                          date: new Date(
+                            invoice.recipientSigningExpiresAt
+                          ).toLocaleDateString()
+                        })}
+                      </p>
+                    ) : null}
+                    {shouldRotateSigningLink && (
+                      <p className="text-warning">
+                        {t('replacement_link_note')}
+                      </p>
+                    )}
+                  </div>
+                </div>
                 <Input
                   defaultValue={defaultRecipientEmail}
                   {...register('recipientEmail')}
@@ -208,85 +240,51 @@ export default function SendInvoiceEmailModal({
                       </span>
                       {invoice.date}
                     </p>
-                    <p className="text-default-500 mt-2 text-sm">
-                      {t('signing_link_note')}
-                    </p>
-                    {invoice.recipientSigningToken && (
-                      <div className="mt-2 flex flex-col gap-2">
-                        {invoice.recipientSigningEmail && (
-                          <p className="text-default-500 text-sm">
-                            {t('active_signing_recipient', {
-                              email: invoice.recipientSigningEmail
-                            })}
-                          </p>
-                        )}
-                        {invoice.recipientSigningRevokedAt ? (
-                          <p className="text-danger text-sm">
-                            {t('signing_link_revoked')}
-                          </p>
-                        ) : invoice.recipientSigningExpiresAt ? (
-                          <p className="text-default-500 text-sm">
-                            {t('signing_link_expires', {
-                              date: new Date(
-                                invoice.recipientSigningExpiresAt
-                              ).toLocaleDateString()
-                            })}
-                          </p>
-                        ) : null}
-                        {shouldRotateSigningLink && (
-                          <p className="text-warning text-sm">
-                            {t('replacement_link_note')}
-                          </p>
-                        )}
-                        <div className="flex flex-wrap gap-2">
-                          {!invoice.recipientSigningRevokedAt && (
-                            <Button
-                              size="sm"
-                              variant="bordered"
-                              color="danger"
-                              isDisabled={isPending}
-                              onPress={() => handleSigningLinkAction('revoke')}
-                            >
-                              {t('revoke_signing_link')}
-                            </Button>
-                          )}
-                          {!invoice.recipientSignedAt && (
-                            <Button
-                              size="sm"
-                              variant="bordered"
-                              isDisabled={isPending}
-                              onPress={() =>
-                                handleSigningLinkAction('regenerate')
-                              }
-                            >
-                              {t('regenerate_signing_link')}
-                            </Button>
-                          )}
-                        </div>
-                      </div>
-                    )}
                   </CardBody>
                 </Card>
               </ModalBody>
-              <ModalFooter className="w-full">
-                <Button
-                  onPress={handleCloseSendDialog}
-                  variant="light"
-                  color="danger"
-                >
-                  {t('cancel')}
-                </Button>
-                <Button
-                  isDisabled={isPending}
-                  isLoading={isPending}
-                  endContent={<PaperAirplaneIcon className="h-4 w-4" />}
-                  color="secondary"
-                  type="submit"
-                >
-                  {shouldRotateSigningLink
-                    ? t('replace_link_and_send')
-                    : t('send')}
-                </Button>
+              <ModalFooter className="flex w-full flex-wrap justify-between gap-2">
+                <div className="flex flex-wrap gap-2">
+                  {invoice.recipientSigningToken &&
+                    !invoice.recipientSigningRevokedAt && (
+                      <Button
+                        size="sm"
+                        variant="light"
+                        color="danger"
+                        isDisabled={isPending}
+                        onPress={() => handleSigningLinkAction('revoke')}
+                      >
+                        {t('revoke_signing_link')}
+                      </Button>
+                    )}
+                  {invoice.recipientSigningToken &&
+                    !invoice.recipientSignedAt && (
+                      <Button
+                        size="sm"
+                        variant="light"
+                        isDisabled={isPending}
+                        onPress={() => handleSigningLinkAction('regenerate')}
+                      >
+                        {t('regenerate_signing_link')}
+                      </Button>
+                    )}
+                </div>
+                <div className="ml-auto flex gap-2">
+                  <Button onPress={handleCloseSendDialog} variant="light">
+                    {t('cancel')}
+                  </Button>
+                  <Button
+                    isDisabled={isPending}
+                    isLoading={isPending}
+                    endContent={<PaperAirplaneIcon className="h-4 w-4" />}
+                    color="secondary"
+                    type="submit"
+                  >
+                    {shouldRotateSigningLink
+                      ? t('replace_link_and_send')
+                      : t('send')}
+                  </Button>
+                </div>
               </ModalFooter>
             </form>
           )}

--- a/client/src/components/invoice/send-invoice-email-modal.tsx
+++ b/client/src/components/invoice/send-invoice-email-modal.tsx
@@ -20,11 +20,15 @@ import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
+import {
+  regenerateInvoiceSigningLink,
+  revokeInvoiceSigningLink,
+  sendInvoiceEmail
+} from '@/api/invoice';
 import { Currency } from '@/lib/types/currency';
 import { InvoiceBody } from '@invoicetrackr/types';
 import { getCurrencySymbol } from '@/lib/utils/currency';
 import { isResponseError } from '@/lib/utils/error';
-import { sendInvoiceEmail } from '@/api/invoice';
 
 type Props = {
   isOpen: boolean;
@@ -56,10 +60,25 @@ export default function SendInvoiceEmailModal({
   const {
     register,
     handleSubmit,
+    getValues,
     reset,
     setError,
+    watch,
     formState: { errors }
   } = useForm<SendInvoiceForm>();
+  const defaultRecipientEmail =
+    invoice.recipientSigningEmail || invoice.receiver.email || '';
+  const recipientEmail = watch('recipientEmail', defaultRecipientEmail);
+  const shouldRotateSigningLink = Boolean(
+    invoice.recipientSigningToken &&
+      (invoice.recipientSigningRevokedAt ||
+        (invoice.recipientSigningExpiresAt &&
+          new Date(invoice.recipientSigningExpiresAt).getTime() <=
+            Date.now()) ||
+        (invoice.recipientSigningEmail &&
+          invoice.recipientSigningEmail.toLowerCase() !==
+            recipientEmail.toLowerCase()))
+  );
 
   const handleCloseSendDialog = () => {
     onClose();
@@ -97,6 +116,29 @@ export default function SendInvoiceEmailModal({
       router.refresh();
     });
 
+  const handleSigningLinkAction = (action: 'revoke' | 'regenerate') =>
+    startTransition(async () => {
+      const response =
+        action === 'revoke'
+          ? await revokeInvoiceSigningLink(userId, Number(invoice.id))
+          : await regenerateInvoiceSigningLink({
+              userId,
+              invoiceId: Number(invoice.id),
+              recipientEmail:
+                getValues('recipientEmail') || defaultRecipientEmail
+            });
+
+      addToast({
+        title: response.data.message,
+        color: isResponseError(response) ? 'danger' : 'success'
+      });
+
+      if (!isResponseError(response)) {
+        handleCloseSendDialog();
+        router.refresh();
+      }
+    });
+
   return (
     <Modal isOpen={isOpen} onClose={handleCloseSendDialog} size="lg">
       <ModalContent>
@@ -113,7 +155,7 @@ export default function SendInvoiceEmailModal({
               </ModalHeader>
               <ModalBody className="w-full">
                 <Input
-                  defaultValue={invoice.receiver.email}
+                  defaultValue={defaultRecipientEmail}
                   {...register('recipientEmail')}
                   variant="faded"
                   label={t('recipient_email')}
@@ -169,6 +211,60 @@ export default function SendInvoiceEmailModal({
                     <p className="text-default-500 mt-2 text-sm">
                       {t('signing_link_note')}
                     </p>
+                    {invoice.recipientSigningToken && (
+                      <div className="mt-2 flex flex-col gap-2">
+                        {invoice.recipientSigningEmail && (
+                          <p className="text-default-500 text-sm">
+                            {t('active_signing_recipient', {
+                              email: invoice.recipientSigningEmail
+                            })}
+                          </p>
+                        )}
+                        {invoice.recipientSigningRevokedAt ? (
+                          <p className="text-danger text-sm">
+                            {t('signing_link_revoked')}
+                          </p>
+                        ) : invoice.recipientSigningExpiresAt ? (
+                          <p className="text-default-500 text-sm">
+                            {t('signing_link_expires', {
+                              date: new Date(
+                                invoice.recipientSigningExpiresAt
+                              ).toLocaleDateString()
+                            })}
+                          </p>
+                        ) : null}
+                        {shouldRotateSigningLink && (
+                          <p className="text-warning text-sm">
+                            {t('replacement_link_note')}
+                          </p>
+                        )}
+                        <div className="flex flex-wrap gap-2">
+                          {!invoice.recipientSigningRevokedAt && (
+                            <Button
+                              size="sm"
+                              variant="bordered"
+                              color="danger"
+                              isDisabled={isPending}
+                              onPress={() => handleSigningLinkAction('revoke')}
+                            >
+                              {t('revoke_signing_link')}
+                            </Button>
+                          )}
+                          {!invoice.recipientSignedAt && (
+                            <Button
+                              size="sm"
+                              variant="bordered"
+                              isDisabled={isPending}
+                              onPress={() =>
+                                handleSigningLinkAction('regenerate')
+                              }
+                            >
+                              {t('regenerate_signing_link')}
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    )}
                   </CardBody>
                 </Card>
               </ModalBody>
@@ -187,7 +283,9 @@ export default function SendInvoiceEmailModal({
                   color="secondary"
                   type="submit"
                 >
-                  {t('send')}
+                  {shouldRotateSigningLink
+                    ? t('replace_link_and_send')
+                    : t('send')}
                 </Button>
               </ModalFooter>
             </form>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "server": "pnpm --filter @invoicetrackr/server",
     "types": "pnpm --filter @invoicetrackr/types",
     "emails": "pnpm --filter @invoicetrackr/emails",
-    "dev": "pnpm run types build && concurrently \"pnpm run types dev\" \"pnpm run server dev\" \"pnpm run client dev:turbo\"",
+    "dev": "pnpm run types build && pnpm run emails build && concurrently \"pnpm run types dev\" \"pnpm run emails dev:watch\" \"pnpm run server dev\" \"pnpm run client dev:turbo\"",
     "build": "pnpm run types build && pnpm run emails build && pnpm run server build && pnpm run client build",
     "lint": "pnpm run client lint && pnpm run server lint",
     "lint:fix": "pnpm run client lint:fix && pnpm run server lint:fix",

--- a/server/drizzle/0019_organic_surge.sql
+++ b/server/drizzle/0019_organic_surge.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "invoices" ADD COLUMN "recipient_signing_email" varchar(255);--> statement-breakpoint
+ALTER TABLE "invoices" ADD COLUMN "recipient_signing_created_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "invoices" ADD COLUMN "recipient_signing_expires_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "invoices" ADD COLUMN "recipient_signing_revoked_at" timestamp with time zone;--> statement-breakpoint
+UPDATE "invoices"
+SET
+  "recipient_signing_created_at" = COALESCE("recipient_signing_sent_at", "recipient_signed_at"),
+  "recipient_signing_expires_at" = CASE
+    WHEN "recipient_signed_at" IS NOT NULL THEN "recipient_signed_at" + INTERVAL '90 days'
+    ELSE "recipient_signing_sent_at" + INTERVAL '30 days'
+  END
+WHERE "recipient_signing_token" IS NOT NULL;

--- a/server/drizzle/meta/0019_snapshot.json
+++ b/server/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1043 @@
+{
+  "id": "d4bb3f0f-de36-4f9b-90b0-44d2914bc288",
+  "prevId": "841abc58-59b7-41cd-b0f2-a429ec47dd00",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.banking_information": {
+      "name": "banking_information",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banking_information_user_id_fkey": {
+          "name": "banking_information_user_id_fkey",
+          "tableFrom": "banking_information",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_clients_user_id": {
+          "name": "fk_clients_user_id",
+          "tableFrom": "clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_banking_information": {
+      "name": "invoice_banking_information",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountName": {
+          "name": "accountName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountNumber": {
+          "name": "accountNumber",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bankCode": {
+          "name": "bankCode",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_banking_information_invoice_id": {
+          "name": "fk_invoice_banking_information_invoice_id",
+          "tableFrom": "invoice_banking_information",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_number_sequences": {
+      "name": "invoice_number_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series": {
+          "name": "series",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_number_sequences_user_id": {
+          "name": "fk_invoice_number_sequences_user_id",
+          "tableFrom": "invoice_number_sequences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_number_sequences_user_series_key": {
+          "name": "invoice_number_sequences_user_series_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_receivers": {
+      "name": "invoice_receivers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_receivers_invoice_id": {
+          "name": "fk_invoice_receivers_invoice_id",
+          "tableFrom": "invoice_receivers",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_senders": {
+      "name": "invoice_senders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_senders_invoice_id": {
+          "name": "fk_invoice_senders_invoice_id",
+          "tableFrom": "invoice_senders",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_services": {
+      "name": "invoice_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_rate": {
+          "name": "vat_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_services_invoice_id": {
+          "name": "fk_invoice_services_invoice_id",
+          "tableFrom": "invoice_services",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "vat_amount": {
+          "name": "vat_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sender_signature": {
+          "name": "sender_signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_signature": {
+          "name": "receiver_signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_token": {
+          "name": "recipient_signing_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_sent_at": {
+          "name": "recipient_signing_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_email": {
+          "name": "recipient_signing_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_created_at": {
+          "name": "recipient_signing_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_expires_at": {
+          "name": "recipient_signing_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_revoked_at": {
+          "name": "recipient_signing_revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signed_at": {
+          "name": "recipient_signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoices_invoice_senders": {
+          "name": "fk_invoices_invoice_senders",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_senders",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_invoices_invoice_receivers": {
+          "name": "fk_invoices_invoice_receivers",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_receivers",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_invoices_invoice_banking_information": {
+          "name": "fk_invoices_invoice_banking_information",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_banking_information",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_user_invoice_id_key": {
+          "name": "invoices_user_invoice_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "invoice_id"
+          ]
+        },
+        "invoices_recipient_signing_token_key": {
+          "name": "invoices_recipient_signing_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipient_signing_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "(status)::text = ANY ((ARRAY['paid'::character varying, 'pending'::character varying, 'canceled'::character varying])::text[])"
+        },
+        "invoices_lifecycle_status_check": {
+          "name": "invoices_lifecycle_status_check",
+          "value": "(lifecycle_status)::text = ANY ((ARRAY['draft'::character varying, 'issued'::character varying, 'voided'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_unique": {
+          "name": "password_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_accounts": {
+      "name": "stripe_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_accounts_user_id_users_id_fk": {
+          "name": "stripe_accounts_user_id_users_id_fk",
+          "tableFrom": "stripe_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_accounts_stripe_customer_id_unique": {
+          "name": "stripe_accounts_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "stripe_accounts_stripe_subscription_id_unique": {
+          "name": "stripe_accounts_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_bank_account_id": {
+          "name": "selected_bank_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_picture_url": {
+          "name": "profile_picture_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_invoice_language": {
+          "name": "preferred_invoice_language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_selected_bank_account": {
+          "name": "fk_selected_bank_account",
+          "tableFrom": "users",
+          "tableTo": "banking_information",
+          "columnsFrom": [
+            "selected_bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1780173356309,
       "tag": "0018_productive_doctor_doom",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1780254023233,
+      "tag": "0019_organic_surge",
+      "breakpoints": true
     }
   ]
 }

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/app.js",
-    "dev": "tsx watch --include ../shared/types/dist/**/* src/app.ts",
+    "dev": "tsx watch --include ../shared/types/dist/**/* --include '../shared/emails/dist/**/*.js' src/app.ts",
     "tsc": "tsc -p tsconfig.json --noEmit",
     "generate": "drizzle-kit generate",
     "migrate": "drizzle-kit migrate",

--- a/server/src/controllers/__tests__/invoice.ts
+++ b/server/src/controllers/__tests__/invoice.ts
@@ -358,7 +358,9 @@ describe('Invoice Controller', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      expect(JSON.parse(response.body).message).toContain('expired');
+      expect(JSON.parse(response.body).message).toBe(
+        'error.invoice.signingLinkExpired'
+      );
 
       await app.close();
     });
@@ -386,7 +388,9 @@ describe('Invoice Controller', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      expect(JSON.parse(response.body).message).toContain('revoked');
+      expect(JSON.parse(response.body).message).toBe(
+        'error.invoice.signingLinkRevoked'
+      );
 
       await app.close();
     });

--- a/server/src/controllers/__tests__/invoice.ts
+++ b/server/src/controllers/__tests__/invoice.ts
@@ -333,4 +333,62 @@ describe('Invoice Controller', () => {
       await app.close();
     });
   });
+
+  describe('GET /api/invoices/sign/:token', () => {
+    it('should reject an expired signing link', async () => {
+      vi.mocked(invoiceDb.getPublicInvoiceSigningFromDb).mockResolvedValue({
+        invoice: invoiceFromDbFactory.build({
+          recipientSigningExpiresAt: new Date(Date.now() - 1000).toISOString()
+        }),
+        currency: 'EUR',
+        language: 'en',
+        preferredInvoiceLanguage: null
+      });
+
+      const app = await createTestApp((fastifyApp) => {
+        fastifyApp.get(
+          '/api/invoices/sign/:token',
+          invoiceController.getPublicInvoiceSigning
+        );
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/invoices/sign/expired-token'
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body).message).toContain('expired');
+
+      await app.close();
+    });
+
+    it('should reject a revoked signing link', async () => {
+      vi.mocked(invoiceDb.getPublicInvoiceSigningFromDb).mockResolvedValue({
+        invoice: invoiceFromDbFactory.build({
+          recipientSigningRevokedAt: new Date().toISOString()
+        }),
+        currency: 'EUR',
+        language: 'en',
+        preferredInvoiceLanguage: null
+      });
+
+      const app = await createTestApp((fastifyApp) => {
+        fastifyApp.get(
+          '/api/invoices/sign/:token',
+          invoiceController.getPublicInvoiceSigning
+        );
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/invoices/sign/revoked-token'
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body).message).toContain('revoked');
+
+      await app.close();
+    });
+  });
 });

--- a/server/src/controllers/invoice.ts
+++ b/server/src/controllers/invoice.ts
@@ -25,6 +25,8 @@ import {
   insertInvoiceInDb,
   markInvoiceSigningSentInDb,
   prepareInvoiceSigningFromDb,
+  regenerateInvoiceSigningFromDb,
+  revokeInvoiceSigningFromDb,
   signInvoiceByRecipientTokenInDb,
   updateInvoiceInDb,
   updateInvoiceStatusInDb
@@ -55,6 +57,35 @@ const escapeEmailHtml = (value: string) =>
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+
+const UNSIGNED_SIGNING_LINK_VALIDITY_DAYS = 30;
+const SIGNED_SIGNING_LINK_VALIDITY_DAYS = 90;
+const createSigningLinkExpiration = (isSigned = false) =>
+  new Date(
+    Date.now() +
+      (isSigned
+        ? SIGNED_SIGNING_LINK_VALIDITY_DAYS
+        : UNSIGNED_SIGNING_LINK_VALIDITY_DAYS) *
+        24 *
+        60 *
+        60 *
+        1000
+  ).toISOString();
+const isSigningLinkExpired = (expiresAt?: string | null) =>
+  Boolean(expiresAt && new Date(expiresAt).getTime() <= Date.now());
+
+const assertSigningLinkAvailable = (
+  invoice: Pick<
+    InvoiceBody,
+    'recipientSigningRevokedAt' | 'recipientSigningExpiresAt'
+  >,
+  i18n: Awaited<ReturnType<typeof useI18n>>
+) => {
+  if (invoice.recipientSigningRevokedAt)
+    throw new BadRequestError(i18n.t('error.invoice.signingLinkRevoked'));
+  if (isSigningLinkExpired(invoice.recipientSigningExpiresAt))
+    throw new BadRequestError(i18n.t('error.invoice.signingLinkExpired'));
+};
 
 export const getInvoices = async (
   req: FastifyRequest<{ Params: { userId: string } }>,
@@ -334,12 +365,41 @@ export const sendInvoiceEmail = async (
   if (!user) throw new NotFoundError(i18n.t('error.user.notFound'));
   if (!invoice) throw new NotFoundError(i18n.t('error.invoice.notFound'));
 
-  const signingToken =
+  let signingToken =
     invoice.recipientSigningToken || randomBytes(32).toString('hex');
+  const shouldRotateSigningLink = Boolean(
+    invoice.recipientSigningToken &&
+      (invoice.recipientSigningRevokedAt ||
+        isSigningLinkExpired(invoice.recipientSigningExpiresAt) ||
+        (invoice.recipientSigningEmail &&
+          invoice.recipientSigningEmail.toLowerCase() !==
+            recipientEmail.toLowerCase()))
+  );
+
+  if (shouldRotateSigningLink) {
+    signingToken = randomBytes(32).toString('hex');
+    const regenerated = await regenerateInvoiceSigningFromDb({
+      userId,
+      id,
+      token: signingToken,
+      recipientEmail,
+      expiresAt: createSigningLinkExpiration(Boolean(invoice.recipientSignedAt))
+    });
+
+    if (!regenerated)
+      throw new BadRequestError(
+        i18n.t('error.invoice.unableToRegenerateSigningLink')
+      );
+  } else if (invoice.recipientSigningToken) {
+    assertSigningLinkAvailable(invoice, i18n);
+  }
+
   const preparedInvoice = await prepareInvoiceSigningFromDb({
     userId,
     id,
-    token: signingToken
+    token: signingToken,
+    recipientEmail,
+    expiresAt: createSigningLinkExpiration(Boolean(invoice.recipientSignedAt))
   });
 
   if (!preparedInvoice?.recipientSigningToken)
@@ -376,12 +436,16 @@ export const sendInvoiceEmail = async (
       signingMessage: i18n.t('emails.invoice.signingMessage'),
       signingButton: i18n.t('emails.invoice.signingButton'),
       signingFallback: i18n.t('emails.invoice.signingFallback'),
+      viewTitle: i18n.t('emails.invoice.viewTitle'),
+      viewMessage: i18n.t('emails.invoice.viewMessage'),
+      viewButton: i18n.t('emails.invoice.viewButton'),
       footer: i18n.t('emails.invoice.footer'),
       copyright: i18n.t('emails.invoice.copyright', {
         year: new Date().getFullYear()
       })
     },
-    signingLink
+    signingLink,
+    isSigningAvailable: !invoice.recipientSignedAt
   });
 
   const { error } = await resend.emails.send({
@@ -409,6 +473,64 @@ export const sendInvoiceEmail = async (
   reply.status(200).send({ message: i18n.t('success.invoice.emailSent') });
 };
 
+export const revokeInvoiceSigning = async (
+  req: FastifyRequest<{ Params: { userId: string; id: string } }>,
+  reply: FastifyReply
+) => {
+  const i18n = await useI18n(req);
+  const userId = Number(req.params.userId);
+  const id = Number(req.params.id);
+  const invoice = await getInvoiceFromDb(userId, id);
+
+  if (!invoice) throw new NotFoundError(i18n.t('error.invoice.notFound'));
+  if (!invoice.recipientSigningToken)
+    throw new BadRequestError(
+      i18n.t('error.invoice.unableToCreateSigningLink')
+    );
+
+  const revoked = await revokeInvoiceSigningFromDb({
+    userId,
+    id
+  });
+
+  if (!revoked) throw new NotFoundError(i18n.t('error.invoice.notFound'));
+
+  reply
+    .status(200)
+    .send({ message: i18n.t('success.invoice.signingLinkRevoked') });
+};
+
+export const regenerateInvoiceSigning = async (
+  req: FastifyRequest<{
+    Params: { userId: string; id: string };
+    Body: { recipientEmail: string };
+  }>,
+  reply: FastifyReply
+) => {
+  const i18n = await useI18n(req);
+  const userId = Number(req.params.userId);
+  const id = Number(req.params.id);
+  const invoice = await getInvoiceFromDb(userId, id);
+
+  if (!invoice) throw new NotFoundError(i18n.t('error.invoice.notFound'));
+  const regenerated = await regenerateInvoiceSigningFromDb({
+    userId,
+    id,
+    token: randomBytes(32).toString('hex'),
+    recipientEmail: req.body.recipientEmail,
+    expiresAt: createSigningLinkExpiration(Boolean(invoice.recipientSignedAt))
+  });
+
+  if (!regenerated)
+    throw new BadRequestError(
+      i18n.t('error.invoice.unableToRegenerateSigningLink')
+    );
+
+  reply.status(200).send({
+    message: i18n.t('success.invoice.signingLinkRegenerated')
+  });
+};
+
 export const getPublicInvoiceSigning = async (
   req: FastifyRequest<{ Params: { token: string } }>,
   reply: FastifyReply
@@ -417,6 +539,7 @@ export const getPublicInvoiceSigning = async (
   const signing = await getPublicInvoiceSigningFromDb(req.params.token);
 
   if (!signing) throw new NotFoundError(i18n.t('error.invoice.notFound'));
+  assertSigningLinkAvailable(signing.invoice, i18n);
 
   reply.status(200).send({
     signing: {
@@ -445,6 +568,7 @@ export const signPublicInvoice = async (
   const signing = await getPublicInvoiceSigningFromDb(req.params.token);
 
   if (!signing) throw new NotFoundError(i18n.t('error.invoice.notFound'));
+  assertSigningLinkAvailable(signing.invoice, i18n);
   if (signing.invoice.recipientSignedAt)
     throw new BadRequestError(i18n.t('error.invoice.alreadySigned'));
 

--- a/server/src/database/invoice.ts
+++ b/server/src/database/invoice.ts
@@ -1,5 +1,5 @@
 import type { InvoiceBody, PublicInvoiceSigning } from '@invoicetrackr/types';
-import { and, desc, eq, gte, inArray, isNull, sql } from 'drizzle-orm';
+import { and, desc, eq, gt, gte, inArray, isNull, or, sql } from 'drizzle-orm';
 
 import {
   bankingInformationTable,
@@ -215,6 +215,10 @@ export const getInvoicesFromDb = async (
       voidedAt: invoicesTable.voidedAt,
       recipientSigningToken: invoicesTable.recipientSigningToken,
       recipientSigningSentAt: invoicesTable.recipientSigningSentAt,
+      recipientSigningEmail: invoicesTable.recipientSigningEmail,
+      recipientSigningCreatedAt: invoicesTable.recipientSigningCreatedAt,
+      recipientSigningExpiresAt: invoicesTable.recipientSigningExpiresAt,
+      recipientSigningRevokedAt: invoicesTable.recipientSigningRevokedAt,
       recipientSignedAt: invoicesTable.recipientSignedAt,
       bankingInformation: {
         id: invoiceBankingInformationTable.id,
@@ -303,6 +307,10 @@ export const getInvoiceFromDb = async (
       voidedAt: invoicesTable.voidedAt,
       recipientSigningToken: invoicesTable.recipientSigningToken,
       recipientSigningSentAt: invoicesTable.recipientSigningSentAt,
+      recipientSigningEmail: invoicesTable.recipientSigningEmail,
+      recipientSigningCreatedAt: invoicesTable.recipientSigningCreatedAt,
+      recipientSigningExpiresAt: invoicesTable.recipientSigningExpiresAt,
+      recipientSigningRevokedAt: invoicesTable.recipientSigningRevokedAt,
       recipientSignedAt: invoicesTable.recipientSignedAt,
       bankingInformation: {
         id: invoiceBankingInformationTable.id,
@@ -501,6 +509,10 @@ export const updateInvoiceInDb = async (
         receiverSignature: invoicesTable.receiverSignature,
         recipientSigningToken: invoicesTable.recipientSigningToken,
         recipientSigningSentAt: invoicesTable.recipientSigningSentAt,
+        recipientSigningEmail: invoicesTable.recipientSigningEmail,
+        recipientSigningCreatedAt: invoicesTable.recipientSigningCreatedAt,
+        recipientSigningExpiresAt: invoicesTable.recipientSigningExpiresAt,
+        recipientSigningRevokedAt: invoicesTable.recipientSigningRevokedAt,
         recipientSignedAt: invoicesTable.recipientSignedAt
       })
       .from(invoicesTable)
@@ -635,6 +647,18 @@ export const updateInvoiceInDb = async (
         recipientSigningSentAt:
           invoiceData.recipientSigningSentAt ??
           currentInvoiceData.recipientSigningSentAt,
+        recipientSigningEmail:
+          invoiceData.recipientSigningEmail ??
+          currentInvoiceData.recipientSigningEmail,
+        recipientSigningCreatedAt:
+          invoiceData.recipientSigningCreatedAt ??
+          currentInvoiceData.recipientSigningCreatedAt,
+        recipientSigningExpiresAt:
+          invoiceData.recipientSigningExpiresAt ??
+          currentInvoiceData.recipientSigningExpiresAt,
+        recipientSigningRevokedAt:
+          invoiceData.recipientSigningRevokedAt ??
+          currentInvoiceData.recipientSigningRevokedAt,
         recipientSignedAt:
           invoiceData.recipientSignedAt ?? currentInvoiceData.recipientSignedAt
       })
@@ -722,11 +746,15 @@ export async function updateInvoiceStatusInDb(
 export async function prepareInvoiceSigningFromDb({
   userId,
   id,
-  token
+  token,
+  recipientEmail,
+  expiresAt
 }: {
   userId: number;
   id: number;
   token: string;
+  recipientEmail: string;
+  expiresAt: string;
 }): Promise<
   | {
       id: number;
@@ -737,13 +765,62 @@ export async function prepareInvoiceSigningFromDb({
   const invoices = await db
     .update(invoicesTable)
     .set({
-      recipientSigningToken: sql<string>`COALESCE(${invoicesTable.recipientSigningToken}, ${token})`
+      recipientSigningToken: sql<string>`COALESCE(${invoicesTable.recipientSigningToken}, ${token})`,
+      recipientSigningEmail: sql<string>`COALESCE(${invoicesTable.recipientSigningEmail}, ${recipientEmail})`,
+      recipientSigningCreatedAt: sql<string>`COALESCE(${invoicesTable.recipientSigningCreatedAt}, ${new Date().toISOString()})`,
+      recipientSigningExpiresAt: sql<string>`COALESCE(${invoicesTable.recipientSigningExpiresAt}, ${expiresAt})`
     })
     .where(and(eq(invoicesTable.id, id), eq(invoicesTable.userId, userId)))
     .returning({
       id: invoicesTable.id,
       recipientSigningToken: invoicesTable.recipientSigningToken
     });
+
+  return invoices.at(0);
+}
+
+export async function revokeInvoiceSigningFromDb({
+  userId,
+  id
+}: {
+  userId: number;
+  id: number;
+}): Promise<{ id: number } | undefined> {
+  const invoices = await db
+    .update(invoicesTable)
+    .set({ recipientSigningRevokedAt: new Date().toISOString() })
+    .where(and(eq(invoicesTable.id, id), eq(invoicesTable.userId, userId)))
+    .returning({ id: invoicesTable.id });
+
+  return invoices.at(0);
+}
+
+export async function regenerateInvoiceSigningFromDb({
+  userId,
+  id,
+  token,
+  recipientEmail,
+  expiresAt
+}: {
+  userId: number;
+  id: number;
+  token: string;
+  recipientEmail: string;
+  expiresAt: string;
+}): Promise<{ id: number } | undefined> {
+  const now = new Date().toISOString();
+  const invoices = await db
+    .update(invoicesTable)
+    .set({
+      recipientSigningToken: token,
+      recipientSigningEmail: recipientEmail,
+      recipientSigningCreatedAt: now,
+      recipientSigningExpiresAt: expiresAt,
+      recipientSigningRevokedAt: null,
+      recipientSigningSentAt: null
+    })
+    .where(and(eq(invoicesTable.id, id), eq(invoicesTable.userId, userId)))
+    .returning({ id: invoicesTable.id });
 
   return invoices.at(0);
 }
@@ -818,12 +895,20 @@ export async function signInvoiceByRecipientTokenInDb({
     .update(invoicesTable)
     .set({
       receiverSignature,
-      recipientSignedAt: new Date().toISOString()
+      recipientSignedAt: new Date().toISOString(),
+      recipientSigningExpiresAt: new Date(
+        Date.now() + 90 * 24 * 60 * 60 * 1000
+      ).toISOString()
     })
     .where(
       and(
         eq(invoicesTable.recipientSigningToken, token),
-        isNull(invoicesTable.recipientSignedAt)
+        isNull(invoicesTable.recipientSignedAt),
+        isNull(invoicesTable.recipientSigningRevokedAt),
+        or(
+          isNull(invoicesTable.recipientSigningExpiresAt),
+          gt(invoicesTable.recipientSigningExpiresAt, new Date().toISOString())
+        )
       )
     )
     .returning({

--- a/server/src/database/schema.ts
+++ b/server/src/database/schema.ts
@@ -69,6 +69,19 @@ export const invoicesTable = pgTable(
       withTimezone: true,
       mode: 'string'
     }),
+    recipientSigningEmail: varchar('recipient_signing_email', { length: 255 }),
+    recipientSigningCreatedAt: timestamp('recipient_signing_created_at', {
+      withTimezone: true,
+      mode: 'string'
+    }),
+    recipientSigningExpiresAt: timestamp('recipient_signing_expires_at', {
+      withTimezone: true,
+      mode: 'string'
+    }),
+    recipientSigningRevokedAt: timestamp('recipient_signing_revoked_at', {
+      withTimezone: true,
+      mode: 'string'
+    }),
     recipientSignedAt: timestamp('recipient_signed_at', {
       withTimezone: true,
       mode: 'string'

--- a/server/src/locales/en.ts
+++ b/server/src/locales/en.ts
@@ -33,6 +33,10 @@ export default {
       signingButton: 'Review and sign',
       signingFallback:
         'If the button does not work, copy and paste this secure link into your browser:',
+      viewTitle: 'View signed invoice',
+      viewMessage:
+        'Open the secure invoice link to review and download the signed PDF.',
+      viewButton: 'View signed invoice',
       footer: 'This email was sent by InvoiceTrackr',
       copyright: 'InvoiceTrackr. All rights reserved.'
     }
@@ -147,7 +151,9 @@ export default {
       deleted: 'Invoice deleted successfully',
       statusUpdated: 'Invoice status updated successfully',
       emailSent: 'Email sent successfully',
-      signed: 'Invoice signed successfully'
+      signed: 'Invoice signed successfully',
+      signingLinkRevoked: 'Signing link revoked',
+      signingLinkRegenerated: 'Fresh signing link generated'
     },
     client: {
       created: 'Client added successfully',
@@ -199,6 +205,12 @@ export default {
       unableToRetrieveData: 'Unable to retrieve invoice data',
       unableToSendEmail: 'Unable to send email',
       unableToCreateSigningLink: 'Unable to create invoice signing link',
+      unableToRegenerateSigningLink:
+        'Unable to regenerate invoice signing link',
+      signingLinkExpired:
+        'This invoice link has expired. Ask the sender for a fresh link.',
+      signingLinkRevoked:
+        'This invoice link has been revoked. Ask the sender for a fresh link.',
       alreadySigned: 'Invoice is already signed',
       issuedImmutable:
         'Issued invoices cannot be edited or deleted from this flow'

--- a/server/src/locales/lt.ts
+++ b/server/src/locales/lt.ts
@@ -35,6 +35,10 @@ export default {
       signingButton: 'Peržiūrėti ir pasirašyti',
       signingFallback:
         'Jei mygtukas neveikia, nukopijuokite ir įklijuokite šią saugią nuorodą į naršyklę:',
+      viewTitle: 'Peržiūrėkite pasirašytą sąskaitą',
+      viewMessage:
+        'Atidarykite saugią sąskaitos nuorodą, peržiūrėkite ir atsisiųskite pasirašytą PDF.',
+      viewButton: 'Peržiūrėti pasirašytą sąskaitą',
       footer: 'Šis el. laiškas buvo išsiųstas InvoiceTrackr',
       copyright: 'InvoiceTrackr. Visos teisės saugomos.'
     }
@@ -151,7 +155,9 @@ export default {
       deleted: 'Sąskaita faktūra ištrinta sėkmingai',
       statusUpdated: 'Sąskaitos faktūros būsena atnaujinta sėkmingai',
       emailSent: 'El. laiškas išsiųstas sėkmingai',
-      signed: 'Sąskaita faktūra pasirašyta sėkmingai'
+      signed: 'Sąskaita faktūra pasirašyta sėkmingai',
+      signingLinkRevoked: 'Pasirašymo nuoroda atšaukta',
+      signingLinkRegenerated: 'Sugeneruota nauja pasirašymo nuoroda'
     },
     client: {
       created: 'Klientas pridėtas sėkmingai',
@@ -204,6 +210,12 @@ export default {
       unableToSendEmail: 'Nepavyko išsiųsti el. laiško',
       unableToCreateSigningLink:
         'Nepavyko sukurti sąskaitos pasirašymo nuorodos',
+      unableToRegenerateSigningLink:
+        'Nepavyko atnaujinti sąskaitos pasirašymo nuorodos',
+      signingLinkExpired:
+        'Šios sąskaitos nuorodos galiojimas baigėsi. Paprašykite siuntėjo naujos nuorodos.',
+      signingLinkRevoked:
+        'Ši sąskaitos nuoroda buvo atšaukta. Paprašykite siuntėjo naujos nuorodos.',
       alreadySigned: 'Sąskaita faktūra jau pasirašyta',
       issuedImmutable:
         'Išrašytų sąskaitų negalima redaguoti ar ištrinti šiame sraute'

--- a/server/src/options/invoice.ts
+++ b/server/src/options/invoice.ts
@@ -26,6 +26,8 @@ import {
   getNextInvoiceNumber,
   getPublicInvoiceSigning,
   postInvoice,
+  regenerateInvoiceSigning,
+  revokeInvoiceSigning,
   sendInvoiceEmail,
   signPublicInvoice,
   updateInvoice,
@@ -158,6 +160,30 @@ export const sendInvoiceEmailOptions: RouteShorthandOptionsWithHandler = {
   preValidation: preValidateFileAndFields,
   handler: sendInvoiceEmail
 };
+
+export const revokeInvoiceSigningOptions: RouteShorthandOptionsWithHandler = {
+  schema: {
+    response: {
+      200: messageResponseSchema
+    }
+  },
+  preHandler: authMiddleware,
+  handler: revokeInvoiceSigning
+};
+
+export const regenerateInvoiceSigningOptions: RouteShorthandOptionsWithHandler =
+  {
+    schema: {
+      body: z.object({
+        recipientEmail: z.email('validation.invoice.recipientEmail')
+      }),
+      response: {
+        200: messageResponseSchema
+      }
+    },
+    preHandler: authMiddleware,
+    handler: regenerateInvoiceSigning
+  };
 
 export const getPublicInvoiceSigningOptions: RouteShorthandOptionsWithHandler =
   {

--- a/server/src/routes/invoice.ts
+++ b/server/src/routes/invoice.ts
@@ -14,6 +14,8 @@ import {
   getNextInvoiceNumberOptions,
   getPublicInvoiceSigningOptions,
   postInvoiceOptions,
+  regenerateInvoiceSigningOptions,
+  revokeInvoiceSigningOptions,
   sendInvoiceEmailOptions,
   signPublicInvoiceOptions,
   updateInvoiceOptions,
@@ -49,6 +51,16 @@ const invoiceRoutes = (
   fastify.get('/api/:userId/invoices/latest', getLatestInvoicesOptions);
 
   fastify.post('/api/:userId/invoices/:id/send-email', sendInvoiceEmailOptions);
+
+  fastify.post(
+    '/api/:userId/invoices/:id/signing-link/revoke',
+    revokeInvoiceSigningOptions
+  );
+
+  fastify.post(
+    '/api/:userId/invoices/:id/signing-link/regenerate',
+    regenerateInvoiceSigningOptions
+  );
 
   fastify.get('/api/invoices/sign/:token', getPublicInvoiceSigningOptions);
 

--- a/shared/emails/emails/invoice-email.tsx
+++ b/shared/emails/emails/invoice-email.tsx
@@ -49,9 +49,9 @@ const InvoiceEmail = ({
 }: InvoiceEmailProps) => {
   return (
     <Html lang="en" dir="ltr">
-      <Head />
-      <Preview>{`${translations.invoiceNumber} #${invoiceNumber} ${translations.from} ${senderName} - ${translations.title}`}</Preview>
       <Tailwind>
+        <Head />
+        <Preview>{`${translations.invoiceNumber} #${invoiceNumber} ${translations.from} ${senderName} - ${translations.title}`}</Preview>
         <Body className="bg-gray-100 font-sans">
           <Container className="mx-auto max-w-[600px] overflow-hidden bg-white shadow-lg">
             <Section className="bg-white px-[32px] py-[24px]">

--- a/shared/emails/emails/invoice-email.tsx
+++ b/shared/emails/emails/invoice-email.tsx
@@ -18,6 +18,7 @@ interface InvoiceEmailProps {
   senderName: string;
   message: string;
   signingLink?: string;
+  isSigningAvailable?: boolean;
   translations: {
     title: string;
     subtitle: string;
@@ -33,6 +34,9 @@ interface InvoiceEmailProps {
     signingMessage: string;
     signingButton: string;
     signingFallback: string;
+    viewTitle: string;
+    viewMessage: string;
+    viewButton: string;
     footer: string;
     copyright: string;
   };
@@ -45,6 +49,7 @@ const InvoiceEmail = ({
   senderName,
   message,
   signingLink,
+  isSigningAvailable = true,
   translations
 }: InvoiceEmailProps) => {
   return (
@@ -132,16 +137,22 @@ const InvoiceEmail = ({
               {signingLink && (
                 <Section className="mt-[16px] rounded-[8px] border border-[#E4D4F4] bg-white p-[20px] text-center">
                   <Text className="m-0 mb-[8px] text-[16px] font-bold text-[#301050]">
-                    {translations.signingTitle}
+                    {isSigningAvailable
+                      ? translations.signingTitle
+                      : translations.viewTitle}
                   </Text>
                   <Text className="mx-0 mb-[18px] mt-0 text-[14px] leading-[20px] text-[#481878]">
-                    {translations.signingMessage}
+                    {isSigningAvailable
+                      ? translations.signingMessage
+                      : translations.viewMessage}
                   </Text>
                   <Link
                     href={signingLink}
                     className="inline-block rounded-[8px] bg-[#7828C8] px-[18px] py-[12px] text-[14px] font-semibold text-white no-underline"
                   >
-                    {translations.signingButton}
+                    {isSigningAvailable
+                      ? translations.signingButton
+                      : translations.viewButton}
                   </Link>
                   <Text className="mx-0 mb-0 mt-[16px] text-left text-[12px] leading-[18px] text-[#6020A0]">
                     {translations.signingFallback}

--- a/shared/emails/package.json
+++ b/shared/emails/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "email dev --dir emails"
+    "dev": "email dev --dir emails",
+    "dev:watch": "tsc --watch"
   },
   "dependencies": {
     "@react-email/components": "^1.0.1",

--- a/shared/types/src/invoice.ts
+++ b/shared/types/src/invoice.ts
@@ -113,6 +113,10 @@ export const invoiceBodySchema = z
     voidedAt: z.string().nullish(),
     recipientSigningToken: z.string().nullish(),
     recipientSigningSentAt: z.string().nullish(),
+    recipientSigningEmail: z.string().nullish(),
+    recipientSigningCreatedAt: z.string().nullish(),
+    recipientSigningExpiresAt: z.string().nullish(),
+    recipientSigningRevokedAt: z.string().nullish(),
     recipientSignedAt: z.string().nullish(),
     services: z
       .array(invoiceServiceBodySchema)


### PR DESCRIPTION
### Overview
Adds lifecycle controls for public invoice signing links and includes the invoice email rendering fix.

  - Add 30-day unsigned signing-link expiration and 90-day signed read-only access.
  - Add revoke, regenerate, and recipient handoff flows.
  - Rotate revoked, expired, or recipient-changed links before resend.
  - Show signing-link state and actions clearly in the send-invoice dialog.
  - Reject expired and revoked public links with recipient-facing messages.
  - Fix invoice React Email rendering and watch shared email templates during local development.
  - Add signing-link migration and focused controller coverage.