### PR TITLE
[REK-49][REK-51] Audit invoice PDF and add pajamų žurnalas export

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -318,6 +318,14 @@
       "total_singular": "Total 1 invoice",
       "total_plural": "Total {count} invoices"
     },
+    "income_journal": {
+      "title": "Export income journal",
+      "description": "The CSV includes invoices paid during the selected period. Unpaid invoices are excluded from the income journal.",
+      "from": "Paid from",
+      "to": "Paid to",
+      "export": "Export CSV",
+      "cancel": "Cancel"
+    },
     "bottom_content": {
       "previous": "Previous",
       "next": "Next"
@@ -352,6 +360,7 @@
       "quantity_label": "Qty",
       "amount_label": "Amount",
       "vat_rate_label": "VAT",
+      "vat_exemption_reason_label": "VAT note",
       "line_total_label": "Line total",
       "subtotal_amount": "Subtotal",
       "vat_amount": "VAT total",
@@ -715,6 +724,7 @@
       "column_quantity": "QUANTITY",
       "column_amount": "AMOUNT",
       "column_vat_rate": "VAT",
+      "column_vat_exemption_reason": "VAT NOTE",
       "column_line_total": "TOTAL",
       "column_actions": "ACTION",
       "add_service": "Add Service",
@@ -730,6 +740,7 @@
         "quantity_label": "Quantity",
         "amount_label": "Amount",
         "vat_rate_label": "VAT Rate",
+        "vat_exemption_reason_label": "VAT exemption or 0% rate note",
         "actions_label": "Actions"
       }
     },

--- a/client/messages/lt.json
+++ b/client/messages/lt.json
@@ -318,6 +318,14 @@
       "total_singular": "Viso 1 sąskaita faktūra",
       "total_plural": "Viso {count} sąskaitų faktūrų"
     },
+    "income_journal": {
+      "title": "Eksportuoti pajamų žurnalą",
+      "description": "CSV faile bus įtrauktos pasirinktu laikotarpiu apmokėtos sąskaitos faktūros. Neapmokėtos sąskaitos į pajamų žurnalą neįtraukiamos.",
+      "from": "Apmokėta nuo",
+      "to": "Apmokėta iki",
+      "export": "Eksportuoti CSV",
+      "cancel": "Atšaukti"
+    },
     "bottom_content": {
       "previous": "Ankstesnis",
       "next": "Kitas"
@@ -352,6 +360,7 @@
       "quantity_label": "Kiekis",
       "amount_label": "Suma",
       "vat_rate_label": "PVM",
+      "vat_exemption_reason_label": "PVM pastaba",
       "line_total_label": "Eilutės suma",
       "subtotal_amount": "Suma be PVM",
       "vat_amount": "PVM suma",
@@ -715,6 +724,7 @@
       "column_quantity": "KIEKIS",
       "column_amount": "SUMA",
       "column_vat_rate": "PVM",
+      "column_vat_exemption_reason": "PVM PASTABA",
       "column_line_total": "VISO",
       "column_actions": "VEIKSMAI",
       "add_service": "Pridėti paslaugą",
@@ -730,6 +740,7 @@
         "quantity_label": "Kiekis",
         "amount_label": "Suma",
         "vat_rate_label": "PVM tarifas",
+        "vat_exemption_reason_label": "PVM išimties arba 0% tarifo pastaba",
         "actions_label": "Veiksmai"
       }
     },

--- a/client/src/api/api-instance.ts
+++ b/client/src/api/api-instance.ts
@@ -55,7 +55,7 @@ class ApiInstance {
         url,
         data: method === 'get' ? undefined : data,
         ...config,
-        params: method === 'get' ? data : config.params
+        params: method === 'get' ? config.params || data : config.params
       });
 
       return response;

--- a/client/src/api/invoice.ts
+++ b/client/src/api/invoice.ts
@@ -27,6 +27,20 @@ export const getPublicInvoiceSigning = async (token: string) =>
 export const getInvoices = async (userId: number) =>
   await api.get<GetInvoicesResponse>(`/api/${userId}/invoices`);
 
+export const getIncomeJournalExport = async ({
+  userId,
+  from,
+  to
+}: {
+  userId: number;
+  from: string;
+  to: string;
+}) =>
+  await api.get<Blob>(`/api/${userId}/invoices/income-journal.csv`, {
+    params: { from, to },
+    responseType: 'blob'
+  });
+
 export const getInvoicesTotalAmount = async (userId: number) =>
   await api.get<GetInvoicesTotalAmountResponse>(
     `/api/${userId}/invoices/total-amount`

--- a/client/src/components/invoice/income-journal-export-modal.tsx
+++ b/client/src/components/invoice/income-journal-export-modal.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  addToast
+} from '@heroui/react';
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { getIncomeJournalExport } from '@/api/invoice';
+import { isResponseError } from '@/lib/utils/error';
+
+type Props = {
+  userId: number;
+  isOpen: boolean;
+  onOpenChange: (_isOpen: boolean) => void;
+};
+
+const currentYear = new Date().getFullYear();
+
+export default function IncomeJournalExportModal({
+  userId,
+  isOpen,
+  onOpenChange
+}: Props) {
+  const t = useTranslations('invoices.income_journal');
+  const [from, setFrom] = useState(`${currentYear}-01-01`);
+  const [to, setTo] = useState(`${currentYear}-12-31`);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    const response = await getIncomeJournalExport({ userId, from, to });
+    setIsExporting(false);
+
+    if (isResponseError(response)) {
+      addToast({ title: response.data.message, color: 'danger' });
+      return;
+    }
+
+    const url = URL.createObjectURL(response.data);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `pajamu-zurnalas-${from}-${to}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+      <ModalContent>
+        {(onClose) => (
+          <>
+            <ModalHeader>{t('title')}</ModalHeader>
+            <ModalBody>
+              <p className="text-default-500 text-sm">{t('description')}</p>
+              <Input
+                type="date"
+                label={t('from')}
+                value={from}
+                onValueChange={setFrom}
+              />
+              <Input
+                type="date"
+                label={t('to')}
+                value={to}
+                onValueChange={setTo}
+              />
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="light" onPress={onClose}>
+                {t('cancel')}
+              </Button>
+              <Button
+                color="secondary"
+                isDisabled={!from || !to || from > to}
+                isLoading={isExporting}
+                onPress={handleExport}
+              >
+                {t('export')}
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/client/src/components/invoice/income-journal-export-modal.tsx
+++ b/client/src/components/invoice/income-journal-export-modal.tsx
@@ -18,6 +18,7 @@ import { isResponseError } from '@/lib/utils/error';
 
 type Props = {
   userId: number;
+  language: string;
   isOpen: boolean;
   onOpenChange: (_isOpen: boolean) => void;
 };
@@ -26,6 +27,7 @@ const currentYear = new Date().getFullYear();
 
 export default function IncomeJournalExportModal({
   userId,
+  language,
   isOpen,
   onOpenChange
 }: Props) {
@@ -36,7 +38,12 @@ export default function IncomeJournalExportModal({
 
   const handleExport = async () => {
     setIsExporting(true);
-    const response = await getIncomeJournalExport({ userId, from, to });
+    const response = await getIncomeJournalExport({
+      userId,
+      from,
+      to,
+      language
+    });
     setIsExporting(false);
 
     if (isResponseError(response)) {
@@ -47,7 +54,10 @@ export default function IncomeJournalExportModal({
     const url = URL.createObjectURL(response.data);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `pajamu-zurnalas-${from}-${to}.csv`;
+    link.download =
+      language === 'lt'
+        ? `pajamu-zurnalas-${from}-${to}.csv`
+        : `income-journal-${from}-${to}.csv`;
     link.click();
     URL.revokeObjectURL(url);
     onOpenChange(false);

--- a/client/src/components/invoice/income-journal-export-modal.tsx
+++ b/client/src/components/invoice/income-journal-export-modal.tsx
@@ -10,15 +10,14 @@ import {
   ModalHeader,
   addToast
 } from '@heroui/react';
+import { useLocale, useTranslations } from 'next-intl';
 import { useState } from 'react';
-import { useTranslations } from 'next-intl';
 
 import { getIncomeJournalExport } from '@/api/invoice';
 import { isResponseError } from '@/lib/utils/error';
 
 type Props = {
   userId: number;
-  language: string;
   isOpen: boolean;
   onOpenChange: (_isOpen: boolean) => void;
 };
@@ -27,11 +26,11 @@ const currentYear = new Date().getFullYear();
 
 export default function IncomeJournalExportModal({
   userId,
-  language,
   isOpen,
   onOpenChange
 }: Props) {
   const t = useTranslations('invoices.income_journal');
+  const locale = useLocale();
   const [from, setFrom] = useState(`${currentYear}-01-01`);
   const [to, setTo] = useState(`${currentYear}-12-31`);
   const [isExporting, setIsExporting] = useState(false);
@@ -41,8 +40,7 @@ export default function IncomeJournalExportModal({
     const response = await getIncomeJournalExport({
       userId,
       from,
-      to,
-      language
+      to
     });
     setIsExporting(false);
 
@@ -55,7 +53,7 @@ export default function IncomeJournalExportModal({
     const link = document.createElement('a');
     link.href = url;
     link.download =
-      language === 'lt'
+      locale === 'lt'
         ? `pajamu-zurnalas-${from}-${to}.csv`
         : `income-journal-${from}-${to}.csv`;
     link.click();

--- a/client/src/components/invoice/invoice-modal.tsx
+++ b/client/src/components/invoice/invoice-modal.tsx
@@ -120,7 +120,7 @@ const InvoiceModal = ({
             </div>
             <div
               className={cn(
-                'bg-default flex items-center gap-1 rounded-lg p-0.5',
+                'bg-default flex shrink-0 items-center gap-1 rounded-lg p-0.5',
                 {
                   'p-0': !userPreferredInvoiceLanguage
                 }
@@ -131,7 +131,7 @@ const InvoiceModal = ({
                   <Select
                     aria-label="Invoice language"
                     size="sm"
-                    className="w-22"
+                    className="min-w-28"
                     variant="bordered"
                     startContent={<LanguageIcon className="min-w-5 max-w-5" />}
                     selectedKeys={[invoiceLanguage]}

--- a/client/src/components/invoice/invoice-services-table.tsx
+++ b/client/src/components/invoice/invoice-services-table.tsx
@@ -55,6 +55,7 @@ const InvoiceServicesTable = ({
     { name: t('column_quantity'), uid: 'quantity' },
     { name: t('column_amount'), uid: 'amount' },
     { name: t('column_vat_rate'), uid: 'vatRate' },
+    { name: t('column_vat_exemption_reason'), uid: 'vatExemptionReason' },
     { name: t('column_line_total'), uid: 'lineTotal' },
     { name: t('column_actions'), uid: 'actions' }
   ];
@@ -214,6 +215,22 @@ const InvoiceServicesTable = ({
             {...register(`services.${index}.vatRate`)}
             isInvalid={!!errors.services?.[index]?.vatRate}
             errorMessage={errors.services?.[index]?.vatRate?.message}
+          />
+        );
+      case 'vatExemptionReason':
+        return (
+          <Input
+            className="min-w-48"
+            aria-label={t('a11y.vat_exemption_reason_label')}
+            type="text"
+            maxLength={255}
+            defaultValue={
+              (fields[index] as InvoiceServiceBody).vatExemptionReason || ''
+            }
+            variant="bordered"
+            {...register(`services.${index}.vatExemptionReason`)}
+            isInvalid={!!errors.services?.[index]?.vatExemptionReason}
+            errorMessage={errors.services?.[index]?.vatExemptionReason?.message}
           />
         );
       case 'lineTotal':

--- a/client/src/components/invoice/invoice-table-top-content.tsx
+++ b/client/src/components/invoice/invoice-table-top-content.tsx
@@ -24,7 +24,6 @@ import IncomeJournalExportModal from './income-journal-export-modal';
 
 type Props = {
   userId: number;
-  language: string;
   columns: Array<{ name: string; uid: string; sortable?: boolean }>;
   statusOptions: Array<{ name: string; uid: string }>;
   filterValue: string;
@@ -40,7 +39,6 @@ type Props = {
 
 const InvoiceTableTopContent = ({
   userId,
-  language,
   columns,
   statusOptions,
   filterValue,
@@ -190,7 +188,6 @@ const InvoiceTableTopContent = ({
       </div>
       <IncomeJournalExportModal
         userId={userId}
-        language={language}
         isOpen={isIncomeJournalModalOpen}
         onOpenChange={onIncomeJournalModalOpenChange}
       />

--- a/client/src/components/invoice/invoice-table-top-content.tsx
+++ b/client/src/components/invoice/invoice-table-top-content.tsx
@@ -24,6 +24,7 @@ import IncomeJournalExportModal from './income-journal-export-modal';
 
 type Props = {
   userId: number;
+  language: string;
   columns: Array<{ name: string; uid: string; sortable?: boolean }>;
   statusOptions: Array<{ name: string; uid: string }>;
   filterValue: string;
@@ -39,6 +40,7 @@ type Props = {
 
 const InvoiceTableTopContent = ({
   userId,
+  language,
   columns,
   statusOptions,
   filterValue,
@@ -188,6 +190,7 @@ const InvoiceTableTopContent = ({
       </div>
       <IncomeJournalExportModal
         userId={userId}
+        language={language}
         isOpen={isIncomeJournalModalOpen}
         onOpenChange={onIncomeJournalModalOpenChange}
       />

--- a/client/src/components/invoice/invoice-table-top-content.tsx
+++ b/client/src/components/invoice/invoice-table-top-content.tsx
@@ -4,11 +4,13 @@ import {
   DropdownItem,
   DropdownMenu,
   DropdownTrigger,
-  Input
+  Input,
+  useDisclosure
 } from '@heroui/react';
 import { ChangeEvent, Dispatch, SetStateAction, useCallback } from 'react';
 import {
   ChevronDownIcon,
+  DocumentArrowDownIcon,
   MagnifyingGlassIcon,
   PlusIcon
 } from '@heroicons/react/24/outline';
@@ -18,7 +20,10 @@ import { useTranslations } from 'next-intl';
 import { ADD_NEW_INVOICE_PAGE } from '@/lib/constants/pages';
 import { capitalize } from '@/lib/utils';
 
+import IncomeJournalExportModal from './income-journal-export-modal';
+
 type Props = {
+  userId: number;
   columns: Array<{ name: string; uid: string; sortable?: boolean }>;
   statusOptions: Array<{ name: string; uid: string }>;
   filterValue: string;
@@ -33,6 +38,7 @@ type Props = {
 };
 
 const InvoiceTableTopContent = ({
+  userId,
   columns,
   statusOptions,
   filterValue,
@@ -47,6 +53,11 @@ const InvoiceTableTopContent = ({
 }: Props) => {
   const t = useTranslations('invoices');
   const router = useRouter();
+  const {
+    isOpen: isIncomeJournalModalOpen,
+    onOpen: openIncomeJournalModal,
+    onOpenChange: onIncomeJournalModalOpenChange
+  } = useDisclosure();
 
   const totalInvoicesText = invoicesLength
     ? invoicesLength === 1
@@ -145,6 +156,13 @@ const InvoiceTableTopContent = ({
             </DropdownMenu>
           </Dropdown>
           <Button
+            variant="flat"
+            endContent={<DocumentArrowDownIcon className="h-4 w-4" />}
+            onPress={openIncomeJournalModal}
+          >
+            {t('income_journal.export')}
+          </Button>
+          <Button
             color="secondary"
             endContent={<PlusIcon className="h-4 w-4" />}
             onPress={handleAddNewInvoice}
@@ -168,6 +186,11 @@ const InvoiceTableTopContent = ({
           </select>
         </label>
       </div>
+      <IncomeJournalExportModal
+        userId={userId}
+        isOpen={isIncomeJournalModalOpen}
+        onOpenChange={onIncomeJournalModalOpenChange}
+      />
     </div>
   );
 };

--- a/client/src/components/invoice/invoice-table.tsx
+++ b/client/src/components/invoice/invoice-table.tsx
@@ -187,6 +187,7 @@ const InvoiceTable = ({
 
   const renderTopContent = () => (
     <InvoiceTableTopContent
+      userId={userId}
       columns={columns}
       statusOptions={statusOptions}
       filterValue={filterValue}

--- a/client/src/components/invoice/invoice-table.tsx
+++ b/client/src/components/invoice/invoice-table.tsx
@@ -188,6 +188,7 @@ const InvoiceTable = ({
   const renderTopContent = () => (
     <InvoiceTableTopContent
       userId={userId}
+      language={language}
       columns={columns}
       statusOptions={statusOptions}
       filterValue={filterValue}

--- a/client/src/components/invoice/invoice-table.tsx
+++ b/client/src/components/invoice/invoice-table.tsx
@@ -188,7 +188,6 @@ const InvoiceTable = ({
   const renderTopContent = () => (
     <InvoiceTableTopContent
       userId={userId}
-      language={language}
       columns={columns}
       statusOptions={statusOptions}
       filterValue={filterValue}

--- a/client/src/components/pdf/pdf-document.tsx
+++ b/client/src/components/pdf/pdf-document.tsx
@@ -61,7 +61,7 @@ export default function PDFDocument({
   const renderHeader = () => (
     <>
       <Text style={pdfStyles.title}>
-        {invoiceData?.sender?.businessType === 'business'
+        {invoiceData?.sender?.vatNumber
           ? t('businessTitle')
           : t('individualTitle')}{' '}
       </Text>
@@ -127,7 +127,8 @@ export default function PDFDocument({
     unit: string,
     quantity: number,
     amount: number,
-    vatRate?: number
+    vatRate?: number,
+    vatExemptionReason?: string
   ) => (
     <View style={pdfStyles.tableRow} key={index}>
       <View style={[pdfStyles.tableCol, pdfStyles.tableCol1]}>
@@ -135,6 +136,11 @@ export default function PDFDocument({
       </View>
       <View style={[pdfStyles.tableCol, pdfStyles.tableCol2]}>
         <Text style={pdfStyles.tableCell}>{description}</Text>
+        {vatExemptionReason && (
+          <Text style={pdfStyles.tableCell}>
+            {t('vat_exemption_reason_label')}: {vatExemptionReason}
+          </Text>
+        )}
       </View>
       <View style={[pdfStyles.tableCol, pdfStyles.tableCol3]}>
         <Text style={pdfStyles.tableCell}>{unit}</Text>
@@ -223,7 +229,8 @@ export default function PDFDocument({
             service.unit,
             service.quantity,
             service.amount,
-            service.vatRate
+            service.vatRate,
+            service.vatExemptionReason
           )
         )}
       </View>

--- a/server/drizzle/0020_romantic_wrecker.sql
+++ b/server/drizzle/0020_romantic_wrecker.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "invoice_services" ADD COLUMN "vat_exemption_reason" text;--> statement-breakpoint
+ALTER TABLE "invoices" ADD COLUMN "supply_date" date;

--- a/server/drizzle/0021_big_vance_astro.sql
+++ b/server/drizzle/0021_big_vance_astro.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "invoices_paid_income_journal_idx" ON "invoices" USING btree ("user_id","paid_at") WHERE status = 'paid';

--- a/server/drizzle/0022_youthful_tana_nile.sql
+++ b/server/drizzle/0022_youthful_tana_nile.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "invoices" DROP COLUMN "supply_date";

--- a/server/drizzle/meta/0020_snapshot.json
+++ b/server/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,1055 @@
+{
+  "id": "4ea13a14-df11-48fd-9f09-ed2386c0f175",
+  "prevId": "d4bb3f0f-de36-4f9b-90b0-44d2914bc288",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.banking_information": {
+      "name": "banking_information",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banking_information_user_id_fkey": {
+          "name": "banking_information_user_id_fkey",
+          "tableFrom": "banking_information",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_clients_user_id": {
+          "name": "fk_clients_user_id",
+          "tableFrom": "clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_banking_information": {
+      "name": "invoice_banking_information",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountName": {
+          "name": "accountName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountNumber": {
+          "name": "accountNumber",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bankCode": {
+          "name": "bankCode",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_banking_information_invoice_id": {
+          "name": "fk_invoice_banking_information_invoice_id",
+          "tableFrom": "invoice_banking_information",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_number_sequences": {
+      "name": "invoice_number_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series": {
+          "name": "series",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_number_sequences_user_id": {
+          "name": "fk_invoice_number_sequences_user_id",
+          "tableFrom": "invoice_number_sequences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_number_sequences_user_series_key": {
+          "name": "invoice_number_sequences_user_series_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_receivers": {
+      "name": "invoice_receivers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_receivers_invoice_id": {
+          "name": "fk_invoice_receivers_invoice_id",
+          "tableFrom": "invoice_receivers",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_senders": {
+      "name": "invoice_senders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_senders_invoice_id": {
+          "name": "fk_invoice_senders_invoice_id",
+          "tableFrom": "invoice_senders",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_services": {
+      "name": "invoice_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_rate": {
+          "name": "vat_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "vat_exemption_reason": {
+          "name": "vat_exemption_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_services_invoice_id": {
+          "name": "fk_invoice_services_invoice_id",
+          "tableFrom": "invoice_services",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supply_date": {
+          "name": "supply_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "vat_amount": {
+          "name": "vat_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sender_signature": {
+          "name": "sender_signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_signature": {
+          "name": "receiver_signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_token": {
+          "name": "recipient_signing_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_sent_at": {
+          "name": "recipient_signing_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_email": {
+          "name": "recipient_signing_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_created_at": {
+          "name": "recipient_signing_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_expires_at": {
+          "name": "recipient_signing_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_revoked_at": {
+          "name": "recipient_signing_revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signed_at": {
+          "name": "recipient_signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoices_invoice_senders": {
+          "name": "fk_invoices_invoice_senders",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_senders",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_invoices_invoice_receivers": {
+          "name": "fk_invoices_invoice_receivers",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_receivers",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_invoices_invoice_banking_information": {
+          "name": "fk_invoices_invoice_banking_information",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_banking_information",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_user_invoice_id_key": {
+          "name": "invoices_user_invoice_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "invoice_id"
+          ]
+        },
+        "invoices_recipient_signing_token_key": {
+          "name": "invoices_recipient_signing_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipient_signing_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "(status)::text = ANY ((ARRAY['paid'::character varying, 'pending'::character varying, 'canceled'::character varying])::text[])"
+        },
+        "invoices_lifecycle_status_check": {
+          "name": "invoices_lifecycle_status_check",
+          "value": "(lifecycle_status)::text = ANY ((ARRAY['draft'::character varying, 'issued'::character varying, 'voided'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_unique": {
+          "name": "password_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_accounts": {
+      "name": "stripe_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_accounts_user_id_users_id_fk": {
+          "name": "stripe_accounts_user_id_users_id_fk",
+          "tableFrom": "stripe_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_accounts_stripe_customer_id_unique": {
+          "name": "stripe_accounts_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "stripe_accounts_stripe_subscription_id_unique": {
+          "name": "stripe_accounts_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_bank_account_id": {
+          "name": "selected_bank_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_picture_url": {
+          "name": "profile_picture_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_invoice_language": {
+          "name": "preferred_invoice_language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_selected_bank_account": {
+          "name": "fk_selected_bank_account",
+          "tableFrom": "users",
+          "tableTo": "banking_information",
+          "columnsFrom": [
+            "selected_bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/0021_snapshot.json
+++ b/server/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1078 @@
+{
+  "id": "ca2bb209-e78e-4d67-8087-1c50f77ec401",
+  "prevId": "4ea13a14-df11-48fd-9f09-ed2386c0f175",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.banking_information": {
+      "name": "banking_information",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banking_information_user_id_fkey": {
+          "name": "banking_information_user_id_fkey",
+          "tableFrom": "banking_information",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_clients_user_id": {
+          "name": "fk_clients_user_id",
+          "tableFrom": "clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_banking_information": {
+      "name": "invoice_banking_information",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountName": {
+          "name": "accountName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountNumber": {
+          "name": "accountNumber",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bankCode": {
+          "name": "bankCode",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_banking_information_invoice_id": {
+          "name": "fk_invoice_banking_information_invoice_id",
+          "tableFrom": "invoice_banking_information",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_number_sequences": {
+      "name": "invoice_number_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series": {
+          "name": "series",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_number_sequences_user_id": {
+          "name": "fk_invoice_number_sequences_user_id",
+          "tableFrom": "invoice_number_sequences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_number_sequences_user_series_key": {
+          "name": "invoice_number_sequences_user_series_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_receivers": {
+      "name": "invoice_receivers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_receivers_invoice_id": {
+          "name": "fk_invoice_receivers_invoice_id",
+          "tableFrom": "invoice_receivers",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_senders": {
+      "name": "invoice_senders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_senders_invoice_id": {
+          "name": "fk_invoice_senders_invoice_id",
+          "tableFrom": "invoice_senders",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_services": {
+      "name": "invoice_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_rate": {
+          "name": "vat_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "vat_exemption_reason": {
+          "name": "vat_exemption_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_services_invoice_id": {
+          "name": "fk_invoice_services_invoice_id",
+          "tableFrom": "invoice_services",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supply_date": {
+          "name": "supply_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "vat_amount": {
+          "name": "vat_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sender_signature": {
+          "name": "sender_signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_signature": {
+          "name": "receiver_signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_token": {
+          "name": "recipient_signing_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_sent_at": {
+          "name": "recipient_signing_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_email": {
+          "name": "recipient_signing_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_created_at": {
+          "name": "recipient_signing_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_expires_at": {
+          "name": "recipient_signing_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_revoked_at": {
+          "name": "recipient_signing_revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signed_at": {
+          "name": "recipient_signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoices_paid_income_journal_idx": {
+          "name": "invoices_paid_income_journal_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "paid_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'paid'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_invoices_invoice_senders": {
+          "name": "fk_invoices_invoice_senders",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_senders",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_invoices_invoice_receivers": {
+          "name": "fk_invoices_invoice_receivers",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_receivers",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_invoices_invoice_banking_information": {
+          "name": "fk_invoices_invoice_banking_information",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_banking_information",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_user_invoice_id_key": {
+          "name": "invoices_user_invoice_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "invoice_id"
+          ]
+        },
+        "invoices_recipient_signing_token_key": {
+          "name": "invoices_recipient_signing_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipient_signing_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "(status)::text = ANY ((ARRAY['paid'::character varying, 'pending'::character varying, 'canceled'::character varying])::text[])"
+        },
+        "invoices_lifecycle_status_check": {
+          "name": "invoices_lifecycle_status_check",
+          "value": "(lifecycle_status)::text = ANY ((ARRAY['draft'::character varying, 'issued'::character varying, 'voided'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_unique": {
+          "name": "password_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_accounts": {
+      "name": "stripe_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_accounts_user_id_users_id_fk": {
+          "name": "stripe_accounts_user_id_users_id_fk",
+          "tableFrom": "stripe_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_accounts_stripe_customer_id_unique": {
+          "name": "stripe_accounts_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "stripe_accounts_stripe_subscription_id_unique": {
+          "name": "stripe_accounts_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_bank_account_id": {
+          "name": "selected_bank_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_picture_url": {
+          "name": "profile_picture_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_invoice_language": {
+          "name": "preferred_invoice_language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_selected_bank_account": {
+          "name": "fk_selected_bank_account",
+          "tableFrom": "users",
+          "tableTo": "banking_information",
+          "columnsFrom": [
+            "selected_bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/0022_snapshot.json
+++ b/server/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1072 @@
+{
+  "id": "1d5e5835-0f2d-41a9-802b-0958218c4290",
+  "prevId": "ca2bb209-e78e-4d67-8087-1c50f77ec401",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.banking_information": {
+      "name": "banking_information",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "banking_information_user_id_fkey": {
+          "name": "banking_information_user_id_fkey",
+          "tableFrom": "banking_information",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_clients_user_id": {
+          "name": "fk_clients_user_id",
+          "tableFrom": "clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_banking_information": {
+      "name": "invoice_banking_information",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountName": {
+          "name": "accountName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountNumber": {
+          "name": "accountNumber",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bankCode": {
+          "name": "bankCode",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_banking_information_invoice_id": {
+          "name": "fk_invoice_banking_information_invoice_id",
+          "tableFrom": "invoice_banking_information",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_number_sequences": {
+      "name": "invoice_number_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series": {
+          "name": "series",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_number_sequences_user_id": {
+          "name": "fk_invoice_number_sequences_user_id",
+          "tableFrom": "invoice_number_sequences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_number_sequences_user_series_key": {
+          "name": "invoice_number_sequences_user_series_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "series"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_receivers": {
+      "name": "invoice_receivers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_receivers_invoice_id": {
+          "name": "fk_invoice_receivers_invoice_id",
+          "tableFrom": "invoice_receivers",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_senders": {
+      "name": "invoice_senders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_senders_invoice_id": {
+          "name": "fk_invoice_senders_invoice_id",
+          "tableFrom": "invoice_senders",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_services": {
+      "name": "invoice_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_rate": {
+          "name": "vat_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "vat_exemption_reason": {
+          "name": "vat_exemption_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_invoice_services_invoice_id": {
+          "name": "fk_invoice_services_invoice_id",
+          "tableFrom": "invoice_services",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal_amount": {
+          "name": "subtotal_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "vat_amount": {
+          "name": "vat_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sender_signature": {
+          "name": "sender_signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_signature": {
+          "name": "receiver_signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_token": {
+          "name": "recipient_signing_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_sent_at": {
+          "name": "recipient_signing_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_email": {
+          "name": "recipient_signing_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_created_at": {
+          "name": "recipient_signing_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_expires_at": {
+          "name": "recipient_signing_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signing_revoked_at": {
+          "name": "recipient_signing_revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_signed_at": {
+          "name": "recipient_signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoices_paid_income_journal_idx": {
+          "name": "invoices_paid_income_journal_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "paid_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'paid'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_invoices_invoice_senders": {
+          "name": "fk_invoices_invoice_senders",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_senders",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_invoices_invoice_receivers": {
+          "name": "fk_invoices_invoice_receivers",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_receivers",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_invoices_invoice_banking_information": {
+          "name": "fk_invoices_invoice_banking_information",
+          "tableFrom": "invoices",
+          "tableTo": "invoice_banking_information",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_user_invoice_id_key": {
+          "name": "invoices_user_invoice_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "invoice_id"
+          ]
+        },
+        "invoices_recipient_signing_token_key": {
+          "name": "invoices_recipient_signing_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipient_signing_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "(status)::text = ANY ((ARRAY['paid'::character varying, 'pending'::character varying, 'canceled'::character varying])::text[])"
+        },
+        "invoices_lifecycle_status_check": {
+          "name": "invoices_lifecycle_status_check",
+          "value": "(lifecycle_status)::text = ANY ((ARRAY['draft'::character varying, 'issued'::character varying, 'voided'::character varying])::text[])"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_unique": {
+          "name": "password_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_accounts": {
+      "name": "stripe_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_accounts_user_id_users_id_fk": {
+          "name": "stripe_accounts_user_id_users_id_fk",
+          "tableFrom": "stripe_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_accounts_stripe_customer_id_unique": {
+          "name": "stripe_accounts_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "stripe_accounts_stripe_subscription_id_unique": {
+          "name": "stripe_accounts_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_number": {
+          "name": "business_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_bank_account_id": {
+          "name": "selected_bank_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_picture_url": {
+          "name": "profile_picture_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_invoice_language": {
+          "name": "preferred_invoice_language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_selected_bank_account": {
+          "name": "fk_selected_bank_account",
+          "tableFrom": "users",
+          "tableTo": "banking_information",
+          "columnsFrom": [
+            "selected_bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -141,6 +141,27 @@
       "when": 1780254023233,
       "tag": "0019_organic_surge",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1780337863758,
+      "tag": "0020_romantic_wrecker",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1780339335917,
+      "tag": "0021_big_vance_astro",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1780342032591,
+      "tag": "0022_youthful_tana_nile",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/controllers/__tests__/invoice.ts
+++ b/server/src/controllers/__tests__/invoice.ts
@@ -86,7 +86,8 @@ describe('Invoice Controller', () => {
 
       const response = await app.inject({
         method: 'GET',
-        url: `/api/${testUserId}/invoices/income-journal.csv?from=2026-05-01&to=2026-05-31&language=en`
+        url: `/api/${testUserId}/invoices/income-journal.csv?from=2026-05-01&to=2026-05-31`,
+        headers: { 'accept-language': 'en' }
       });
 
       expect(response.statusCode).toBe(200);
@@ -122,7 +123,8 @@ describe('Invoice Controller', () => {
 
       const response = await app.inject({
         method: 'GET',
-        url: `/api/${testUserId}/invoices/income-journal.csv?from=2026-05-01&to=2026-05-31&language=lt`
+        url: `/api/${testUserId}/invoices/income-journal.csv?from=2026-05-01&to=2026-05-31`,
+        headers: { 'accept-language': 'lt' }
       });
 
       expect(response.headers['content-disposition']).toBe(

--- a/server/src/controllers/__tests__/invoice.ts
+++ b/server/src/controllers/__tests__/invoice.ts
@@ -55,6 +55,57 @@ describe('Invoice Controller', () => {
     });
   });
 
+  describe('GET /api/:userId/invoices/income-journal.csv', () => {
+    it('should export paid income journal rows as CSV', async () => {
+      vi.mocked(invoiceDb.getIncomeJournalRowsFromDb).mockResolvedValue([
+        {
+          paidAt: '2026-05-20T10:00:00.000Z',
+          date: '2026-05-15',
+          invoiceId: 'SF001',
+          receiverName: 'Test Client',
+          receiverBusinessNumber: '123456789',
+          descriptions: 'Consulting, implementation',
+          subtotalAmount: '100.00',
+          vatAmount: '21.00',
+          totalAmount: '121.00',
+          currency: 'eur'
+        }
+      ]);
+
+      const { getIncomeJournal } = invoiceController;
+
+      const app = await createTestApp((fastifyApp) => {
+        fastifyApp.get(
+          '/api/:userId/invoices/income-journal.csv',
+          {
+            preHandler: mockAuthMiddleware
+          },
+          getIncomeJournal
+        );
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/${testUserId}/invoices/income-journal.csv?from=2026-05-01&to=2026-05-31`
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toContain('text/csv');
+      expect(response.headers['content-disposition']).toBe(
+        'attachment; filename="pajamu-zurnalas-2026-05-01-2026-05-31.csv"'
+      );
+      expect(response.body).toContain('\uFEFF"Apmokėjimo data"');
+      expect(response.body).toContain('"Consulting, implementation"');
+      expect(invoiceDb.getIncomeJournalRowsFromDb).toHaveBeenCalledWith({
+        userId: testUserId,
+        from: '2026-05-01',
+        to: '2026-05-31'
+      });
+
+      await app.close();
+    });
+  });
+
   describe('GET /api/:userId/invoices/:id', () => {
     it('should return a specific invoice', async () => {
       vi.mocked(invoiceDb.getInvoiceFromDb).mockResolvedValue(mockInvoiceForDb);

--- a/server/src/controllers/__tests__/invoice.ts
+++ b/server/src/controllers/__tests__/invoice.ts
@@ -86,21 +86,49 @@ describe('Invoice Controller', () => {
 
       const response = await app.inject({
         method: 'GET',
-        url: `/api/${testUserId}/invoices/income-journal.csv?from=2026-05-01&to=2026-05-31`
+        url: `/api/${testUserId}/invoices/income-journal.csv?from=2026-05-01&to=2026-05-31&language=en`
       });
 
       expect(response.statusCode).toBe(200);
       expect(response.headers['content-type']).toContain('text/csv');
       expect(response.headers['content-disposition']).toBe(
-        'attachment; filename="pajamu-zurnalas-2026-05-01-2026-05-31.csv"'
+        'attachment; filename="income-journal-2026-05-01-2026-05-31.csv"'
       );
-      expect(response.body).toContain('\uFEFF"Apmokėjimo data"');
+      expect(response.body).toContain('\uFEFF"Payment date"');
       expect(response.body).toContain('"Consulting, implementation"');
       expect(invoiceDb.getIncomeJournalRowsFromDb).toHaveBeenCalledWith({
         userId: testUserId,
         from: '2026-05-01',
         to: '2026-05-31'
       });
+
+      await app.close();
+    });
+
+    it('should export Lithuanian headers and filename for Lithuanian users', async () => {
+      vi.mocked(invoiceDb.getIncomeJournalRowsFromDb).mockResolvedValue([]);
+
+      const { getIncomeJournal } = invoiceController;
+
+      const app = await createTestApp((fastifyApp) => {
+        fastifyApp.get(
+          '/api/:userId/invoices/income-journal.csv',
+          {
+            preHandler: mockAuthMiddleware
+          },
+          getIncomeJournal
+        );
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/${testUserId}/invoices/income-journal.csv?from=2026-05-01&to=2026-05-31&language=lt`
+      });
+
+      expect(response.headers['content-disposition']).toBe(
+        'attachment; filename="pajamu-zurnalas-2026-05-01-2026-05-31.csv"'
+      );
+      expect(response.body).toContain('\uFEFF"Apmokėjimo data"');
 
       await app.close();
     });

--- a/server/src/controllers/invoice.ts
+++ b/server/src/controllers/invoice.ts
@@ -112,10 +112,10 @@ export const getIncomeJournal = async (
   reply: FastifyReply
 ) => {
   const userId = Number(req.params.userId);
-  const { from, to, language } = req.query;
+  const { from, to } = req.query;
   const rows = await getIncomeJournalRowsFromDb({ userId, from, to });
   const currency = rows.at(0)?.currency?.toUpperCase() || 'EUR';
-  const isLithuanian = language === 'lt';
+  const isLithuanian = req.headers['accept-language']?.startsWith('lt');
   const headers = isLithuanian
     ? [
         'Apmokėjimo data',

--- a/server/src/controllers/invoice.ts
+++ b/server/src/controllers/invoice.ts
@@ -112,20 +112,34 @@ export const getIncomeJournal = async (
   reply: FastifyReply
 ) => {
   const userId = Number(req.params.userId);
-  const { from, to } = req.query;
+  const { from, to, language } = req.query;
   const rows = await getIncomeJournalRowsFromDb({ userId, from, to });
   const currency = rows.at(0)?.currency?.toUpperCase() || 'EUR';
-  const headers = [
-    'Apmokėjimo data',
-    'Sąskaitos data',
-    'Dokumento numeris',
-    'Pirkėjas',
-    'Pirkėjo kodas',
-    'Paslaugos / prekės',
-    `Suma be PVM (${currency})`,
-    `PVM suma (${currency})`,
-    `Bendra suma (${currency})`
-  ];
+  const isLithuanian = language === 'lt';
+  const headers = isLithuanian
+    ? [
+        'Apmokėjimo data',
+        'Sąskaitos data',
+        'Dokumento numeris',
+        'Pirkėjas',
+        'Pirkėjo kodas',
+        'Paslaugos / prekės',
+        `Suma be PVM (${currency})`,
+        `PVM suma (${currency})`,
+        `Bendra suma (${currency})`
+      ]
+    : [
+        'Payment date',
+        'Invoice date',
+        'Document number',
+        'Client',
+        'Client code',
+        'Services / goods',
+        `Subtotal (${currency})`,
+        `VAT total (${currency})`,
+        `Grand total (${currency})`
+      ];
+  const filename = isLithuanian ? 'pajamu-zurnalas' : 'income-journal';
   const csvRows = rows.map((row) =>
     [
       formatCsvDate(row.paidAt),
@@ -146,10 +160,12 @@ export const getIncomeJournal = async (
     .header('Content-Type', 'text/csv; charset=utf-8')
     .header(
       'Content-Disposition',
-      `attachment; filename="pajamu-zurnalas-${from}-${to}.csv"`
+      `attachment; filename="${filename}-${from}-${to}.csv"`
     )
     .status(200)
-    .send(`\uFEFF${[headers.map(escapeCsvValue).join(','), ...csvRows].join('\n')}`);
+    .send(
+      `\uFEFF${[headers.map(escapeCsvValue).join(','), ...csvRows].join('\n')}`
+    );
 };
 
 export const getInvoice = async (

--- a/server/src/controllers/invoice.ts
+++ b/server/src/controllers/invoice.ts
@@ -1,5 +1,5 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
-import type { InvoiceBody } from '@invoicetrackr/types';
+import type { IncomeJournalQuery, InvoiceBody } from '@invoicetrackr/types';
 import { InvoiceEmail } from '@invoicetrackr/emails';
 import { MultipartFile } from '@fastify/multipart';
 import { v2 as cloudinary } from 'cloudinary';
@@ -15,6 +15,7 @@ import {
   deleteInvoiceFromDb,
   findInvoiceById,
   findInvoiceByInvoiceId,
+  getIncomeJournalRowsFromDb,
   getInvoiceFromDb,
   getInvoicesFromDb,
   getInvoicesRevenueFromDb,
@@ -58,6 +59,12 @@ const escapeEmailHtml = (value: string) =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 
+const escapeCsvValue = (value: string | null | undefined) =>
+  `"${String(value || '').replace(/"/g, '""')}"`;
+
+const formatCsvDate = (value: string | null | undefined) =>
+  value ? value.slice(0, 10) : '';
+
 const UNSIGNED_SIGNING_LINK_VALIDITY_DAYS = 30;
 const SIGNED_SIGNING_LINK_VALIDITY_DAYS = 90;
 const createSigningLinkExpiration = (isSigned = false) =>
@@ -95,6 +102,54 @@ export const getInvoices = async (
   const invoices = await getInvoicesFromDb(userId);
 
   reply.status(200).send({ invoices });
+};
+
+export const getIncomeJournal = async (
+  req: FastifyRequest<{
+    Params: { userId: string };
+    Querystring: IncomeJournalQuery;
+  }>,
+  reply: FastifyReply
+) => {
+  const userId = Number(req.params.userId);
+  const { from, to } = req.query;
+  const rows = await getIncomeJournalRowsFromDb({ userId, from, to });
+  const currency = rows.at(0)?.currency?.toUpperCase() || 'EUR';
+  const headers = [
+    'Apmokėjimo data',
+    'Sąskaitos data',
+    'Dokumento numeris',
+    'Pirkėjas',
+    'Pirkėjo kodas',
+    'Paslaugos / prekės',
+    `Suma be PVM (${currency})`,
+    `PVM suma (${currency})`,
+    `Bendra suma (${currency})`
+  ];
+  const csvRows = rows.map((row) =>
+    [
+      formatCsvDate(row.paidAt),
+      row.date,
+      row.invoiceId,
+      row.receiverName,
+      row.receiverBusinessNumber,
+      row.descriptions,
+      row.subtotalAmount,
+      row.vatAmount,
+      row.totalAmount
+    ]
+      .map(escapeCsvValue)
+      .join(',')
+  );
+
+  reply
+    .header('Content-Type', 'text/csv; charset=utf-8')
+    .header(
+      'Content-Disposition',
+      `attachment; filename="pajamu-zurnalas-${from}-${to}.csv"`
+    )
+    .status(200)
+    .send(`\uFEFF${[headers.map(escapeCsvValue).join(','), ...csvRows].join('\n')}`);
 };
 
 export const getInvoice = async (

--- a/server/src/database/invoice.ts
+++ b/server/src/database/invoice.ts
@@ -1,5 +1,16 @@
 import type { InvoiceBody, PublicInvoiceSigning } from '@invoicetrackr/types';
-import { and, desc, eq, gt, gte, inArray, isNull, or, sql } from 'drizzle-orm';
+import {
+  and,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNull,
+  lte,
+  or,
+  sql
+} from 'drizzle-orm';
 
 import {
   bankingInformationTable,
@@ -252,7 +263,8 @@ export const getInvoicesFromDb = async (
         amount: invoiceServicesTable.amount,
         quantity: invoiceServicesTable.quantity,
         unit: invoiceServicesTable.unit,
-        vatRate: invoiceServicesTable.vatRate
+        vatRate: invoiceServicesTable.vatRate,
+        vatExemptionReason: invoiceServicesTable.vatExemptionReason
       })
     })
     .from(invoicesTable)
@@ -344,7 +356,8 @@ export const getInvoiceFromDb = async (
         amount: invoiceServicesTable.amount,
         quantity: invoiceServicesTable.quantity,
         unit: invoiceServicesTable.unit,
-        vatRate: invoiceServicesTable.vatRate
+        vatRate: invoiceServicesTable.vatRate,
+        vatExemptionReason: invoiceServicesTable.vatExemptionReason
       })
     })
     .from(invoicesTable)
@@ -398,6 +411,14 @@ export const insertInvoiceInDb = async (
         vatAmount: totals.vatAmount,
         totalAmount: totals.totalAmount,
         status: invoiceData.status,
+        paidAt:
+          invoiceData.status === 'paid'
+            ? invoiceData.paidAt || new Date().toISOString()
+            : null,
+        voidedAt:
+          invoiceData.status === 'canceled'
+            ? invoiceData.voidedAt || new Date().toISOString()
+            : null,
         lifecycleStatus: invoiceData.lifecycleStatus || 'draft',
         dueDate: invoiceData.dueDate,
         senderSignature: senderSignature,
@@ -460,6 +481,7 @@ export const insertInvoiceInDb = async (
         quantity: service.quantity,
         amount: String(service.amount),
         vatRate: String(service.vatRate || 0),
+        vatExemptionReason: service.vatExemptionReason || null,
         unit: service.unit,
         description: service.description,
         invoiceId: insertedInvoiceId
@@ -521,6 +543,18 @@ export const updateInvoiceInDb = async (
     if (!currentInvoice[0]) return null;
 
     const currentInvoiceData = currentInvoice[0];
+    const paidAt =
+      invoiceData.status === 'paid'
+        ? invoiceData.paidAt ||
+          currentInvoiceData.paidAt ||
+          new Date().toISOString()
+        : null;
+    const voidedAt =
+      invoiceData.status === 'canceled'
+        ? invoiceData.voidedAt ||
+          currentInvoiceData.voidedAt ||
+          new Date().toISOString()
+        : null;
 
     // Update the existing sender record
     if (currentInvoiceData.senderId) {
@@ -636,8 +670,8 @@ export const updateInvoiceInDb = async (
         vatAmount: totals.vatAmount,
         totalAmount: totals.totalAmount,
         issuedAt: invoiceData.issuedAt ?? currentInvoiceData.issuedAt,
-        paidAt: invoiceData.paidAt ?? currentInvoiceData.paidAt,
-        voidedAt: invoiceData.voidedAt ?? currentInvoiceData.voidedAt,
+        paidAt,
+        voidedAt,
         senderSignature,
         receiverSignature:
           invoiceData.receiverSignature ?? currentInvoiceData.receiverSignature,
@@ -700,6 +734,7 @@ export const updateInvoiceInDb = async (
             description: service.description,
             amount: String(service.amount),
             vatRate: String(service.vatRate || 0),
+            vatExemptionReason: service.vatExemptionReason || null,
             quantity: service.quantity,
             unit: service.unit
           })
@@ -709,6 +744,7 @@ export const updateInvoiceInDb = async (
           description: service.description,
           amount: String(service.amount),
           vatRate: String(service.vatRate || 0),
+          vatExemptionReason: service.vatExemptionReason || null,
           quantity: service.quantity,
           unit: service.unit,
           invoiceId: id
@@ -729,7 +765,10 @@ export async function updateInvoiceStatusInDb(
 ): Promise<{ id: number } | undefined> {
   const timestampUpdates =
     status === 'paid'
-      ? { paidAt: new Date().toISOString(), voidedAt: null }
+      ? {
+          paidAt: sql<string>`COALESCE(${invoicesTable.paidAt}, CURRENT_TIMESTAMP)`,
+          voidedAt: null
+        }
       : status === 'canceled'
         ? { paidAt: null, voidedAt: new Date().toISOString() }
         : { paidAt: null, voidedAt: null };
@@ -994,4 +1033,54 @@ export const getLatestInvoicesFromDb = async (userId: number) => {
     .limit(5);
 
   return invoices;
+};
+
+export const getIncomeJournalRowsFromDb = async ({
+  userId,
+  from,
+  to
+}: {
+  userId: number;
+  from: string;
+  to: string;
+}) => {
+  const effectivePaidAt = sql<string>`COALESCE(${invoicesTable.paidAt}, ${invoicesTable.date}::timestamp with time zone)`;
+
+  return db
+    .select({
+      paidAt: effectivePaidAt,
+      date: invoicesTable.date,
+      invoiceId: invoicesTable.invoiceId,
+      receiverName: invoiceReceiversTable.name,
+      receiverBusinessNumber: invoiceReceiversTable.businessNumber,
+      descriptions: sql<string>`STRING_AGG(${invoiceServicesTable.description}, '; ' ORDER BY ${invoiceServicesTable.id})`,
+      subtotalAmount: invoicesTable.subtotalAmount,
+      vatAmount: invoicesTable.vatAmount,
+      totalAmount: invoicesTable.totalAmount,
+      currency: usersTable.currency
+    })
+    .from(invoicesTable)
+    .innerJoin(
+      invoiceReceiversTable,
+      eq(invoicesTable.receiverId, invoiceReceiversTable.id)
+    )
+    .innerJoin(
+      invoiceServicesTable,
+      eq(invoiceServicesTable.invoiceId, invoicesTable.id)
+    )
+    .innerJoin(usersTable, eq(invoicesTable.userId, usersTable.id))
+    .where(
+      and(
+        eq(invoicesTable.userId, userId),
+        eq(invoicesTable.status, 'paid'),
+        gte(effectivePaidAt, `${from}T00:00:00.000Z`),
+        lte(effectivePaidAt, `${to}T23:59:59.999Z`)
+      )
+    )
+    .groupBy(
+      invoicesTable.id,
+      invoiceReceiversTable.id,
+      usersTable.currency
+    )
+    .orderBy(effectivePaidAt, invoicesTable.id);
 };

--- a/server/src/database/schema.ts
+++ b/server/src/database/schema.ts
@@ -2,6 +2,7 @@ import {
   check,
   date,
   foreignKey,
+  index,
   integer,
   numeric,
   pgTable,
@@ -24,7 +25,8 @@ export const invoiceServicesTable = pgTable(
     amount: numeric({ precision: 10, scale: 2 }).notNull(),
     vatRate: numeric('vat_rate', { precision: 5, scale: 2 })
       .default('0')
-      .notNull()
+      .notNull(),
+    vatExemptionReason: text('vat_exemption_reason')
   },
   (table) => [
     foreignKey({
@@ -126,7 +128,10 @@ export const invoicesTable = pgTable(
     unique('invoices_user_invoice_id_key').on(table.userId, table.invoiceId),
     unique('invoices_recipient_signing_token_key').on(
       table.recipientSigningToken
-    )
+    ),
+    index('invoices_paid_income_journal_idx')
+      .on(table.userId, table.paidAt)
+      .where(sql`status = 'paid'`)
   ]
 );
 

--- a/server/src/locales/en.ts
+++ b/server/src/locales/en.ts
@@ -60,6 +60,7 @@ export default {
       date: 'Valid date is required',
       dueDate: 'Valid date is required',
       dueDateAfterDate: 'Due date must be after invoice date',
+      incomeJournalDateRange: 'End date must not be before start date',
       status: 'Valid status is required',
       businessType: '"Business" or "Individual" required',
       partyType: 'Valid party type is required',

--- a/server/src/locales/lt.ts
+++ b/server/src/locales/lt.ts
@@ -62,6 +62,7 @@ export default {
       date: 'Reikalinga tinkama data',
       dueDate: 'Reikalinga tinkama data',
       dueDateAfterDate: 'Terminas neturi būti ankstesnis už sąskaitos datą',
+      incomeJournalDateRange: 'Pabaigos data negali būti ankstesnė už pradžios datą',
       status: 'Tinkama būsena yra privaloma',
       businessType: 'Reikalingas "Verslas" arba "Fizinis asmuo"',
       partyType: 'Tinkamas šalies tipas yra privalomas',

--- a/server/src/options/invoice.ts
+++ b/server/src/options/invoice.ts
@@ -19,9 +19,9 @@ import z from 'zod/v4';
 
 import {
   deleteInvoice,
+  getIncomeJournal,
   getInvoice,
   getInvoices,
-  getIncomeJournal,
   getInvoicesRevenue,
   getInvoicesTotalAmount,
   getLatestInvoices,

--- a/server/src/options/invoice.ts
+++ b/server/src/options/invoice.ts
@@ -6,6 +6,7 @@ import {
   getLatestInvoicesResponseSchema,
   getNextInvoiceNumberResponseSchema,
   getPublicInvoiceSigningResponseSchema,
+  incomeJournalQuerySchema,
   invoiceBodySchema,
   invoiceNumberSeriesSchema,
   messageResponseSchema,
@@ -20,6 +21,7 @@ import {
   deleteInvoice,
   getInvoice,
   getInvoices,
+  getIncomeJournal,
   getInvoicesRevenue,
   getInvoicesTotalAmount,
   getLatestInvoices,
@@ -44,6 +46,14 @@ export const getInvoicesOptions: RouteShorthandOptionsWithHandler = {
   },
   preHandler: authMiddleware,
   handler: getInvoices
+};
+
+export const getIncomeJournalOptions: RouteShorthandOptionsWithHandler = {
+  schema: {
+    querystring: incomeJournalQuerySchema
+  },
+  preHandler: authMiddleware,
+  handler: getIncomeJournal
 };
 
 export const getInvoiceOptions: RouteShorthandOptionsWithHandler = {

--- a/server/src/routes/invoice.ts
+++ b/server/src/routes/invoice.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   deleteInvoiceOptions,
+  getIncomeJournalOptions,
   getInvoiceOptions,
   getInvoicesOptions,
   getInvoicesRevenueOptions,
@@ -28,6 +29,11 @@ const invoiceRoutes = (
   done: DoneFuncWithErrOrRes
 ) => {
   fastify.get('/api/:userId/invoices', getInvoicesOptions);
+
+  fastify.get(
+    '/api/:userId/invoices/income-journal.csv',
+    getIncomeJournalOptions
+  );
 
   fastify.get('/api/:userId/invoices/next-number', getNextInvoiceNumberOptions);
 

--- a/server/src/test/factories/invoice.ts
+++ b/server/src/test/factories/invoice.ts
@@ -84,7 +84,8 @@ export const invoiceFromDbFactory = Factory.define<InvoiceFromDb>(
         unit: 'hour',
         quantity: 10,
         amount: '100.00',
-        vatRate: '0.00'
+        vatRate: '0.00',
+        vatExemptionReason: null
       }
     ]
   })

--- a/shared/types/src/invoice.ts
+++ b/shared/types/src/invoice.ts
@@ -148,7 +148,8 @@ export const signInvoiceBodySchema = z.object({
 export const incomeJournalQuerySchema = z
   .object({
     from: z.iso.date(),
-    to: z.iso.date()
+    to: z.iso.date(),
+    language: z.enum(['en', 'lt']).default('en')
   })
   .refine((data) => data.from <= data.to, {
     message: 'validation.invoice.incomeJournalDateRange',

--- a/shared/types/src/invoice.ts
+++ b/shared/types/src/invoice.ts
@@ -148,8 +148,7 @@ export const signInvoiceBodySchema = z.object({
 export const incomeJournalQuerySchema = z
   .object({
     from: z.iso.date(),
-    to: z.iso.date(),
-    language: z.enum(['en', 'lt']).default('en')
+    to: z.iso.date()
   })
   .refine((data) => data.from <= data.to, {
     message: 'validation.invoice.incomeJournalDateRange',

--- a/shared/types/src/invoice.ts
+++ b/shared/types/src/invoice.ts
@@ -51,7 +51,8 @@ export const invoiceServiceBodySchema = z.object({
     .number('validation.invoice.services.amount.number')
     .min(0.01, 'validation.invoice.services.amount.min')
     .max(10000000, 'validation.invoice.services.amount.max'),
-  vatRate: z.coerce.number().min(0).max(100).optional()
+  vatRate: z.coerce.number().min(0).max(100).optional(),
+  vatExemptionReason: z.string().trim().max(255).nullish()
 });
 
 export const invoiceSenderBodySchema = z.object(
@@ -144,6 +145,16 @@ export const signInvoiceBodySchema = z.object({
   file: z.any()
 });
 
+export const incomeJournalQuerySchema = z
+  .object({
+    from: z.iso.date(),
+    to: z.iso.date()
+  })
+  .refine((data) => data.from <= data.to, {
+    message: 'validation.invoice.incomeJournalDateRange',
+    path: ['to']
+  });
+
 // Types
 export type InvoiceStatus = z.infer<typeof invoiceStatusSchema>;
 export type InvoiceNumberSeries = z.infer<typeof invoiceNumberSeriesSchema>;
@@ -165,3 +176,4 @@ export type InvoiceParty = InvoicePartyBody;
 
 export type InvoiceBody = z.infer<typeof invoiceBodySchema>;
 export type PublicInvoiceSigning = z.infer<typeof publicInvoiceSigningSchema>;
+export type IncomeJournalQuery = z.infer<typeof incomeJournalQuerySchema>;


### PR DESCRIPTION
### Overview

Improve Lithuania-first invoice output and add a practical paid-income journal CSV export.

  - Make the PVM invoice title depend on the sender VAT number.
  - Add optional per-line VAT notes for 0% or VAT-exempt treatment.
  - Add a paid-income CSV export with payment-date filtering.
  - Include invoice number, client details, services, subtotal, VAT, and total.
  - Preserve GET query parameters and support legacy paid invoices without recorded payment timestamps.
  - Add Drizzle migrations and a focused CSV controller test.
