### PR TITLE
[REK-73] Fix auth validation state

### DIFF
--- a/client/src/components/auth/__tests__/auth-forms.test.tsx
+++ b/client/src/components/auth/__tests__/auth-forms.test.tsx
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { withIntl } from '@/test/with-intl';
+
+import CreateNewPasswordForm from '../create-new-password-form';
+import ForgotPasswordForm from '../forgot-password-form';
+import LoginForm from '../login-form';
+import SignUpForm from '../sign-up-form';
+
+const mockAuthenticateAction = vi.fn();
+const mockCreateNewPasswordAction = vi.fn();
+const mockResetPasswordAction = vi.fn();
+const mockSignUpAction = vi.fn();
+
+vi.mock('@/lib/actions', () => ({
+  authenticateAction: (...args: Array<unknown>) =>
+    mockAuthenticateAction(...args),
+  createNewPasswordAction: (...args: Array<unknown>) =>
+    mockCreateNewPasswordAction(...args),
+  resetPasswordAction: (...args: Array<unknown>) =>
+    mockResetPasswordAction(...args),
+  signUpAction: (...args: Array<unknown>) => mockSignUpAction(...args)
+}));
+
+describe('auth forms', () => {
+  beforeEach(() => {
+    mockAuthenticateAction.mockResolvedValue(undefined);
+    mockCreateNewPasswordAction.mockResolvedValue({
+      ok: true,
+      message: 'Password changed'
+    });
+    mockResetPasswordAction.mockResolvedValue({
+      ok: true,
+      message: 'Reset link sent'
+    });
+    mockSignUpAction.mockResolvedValue({
+      ok: true,
+      message: ''
+    });
+  });
+
+  it('keeps signup values and clears the stale password validation error', async () => {
+    mockSignUpAction.mockResolvedValue({
+      ok: false,
+      message: 'Validation failed',
+      errors: {
+        email: '',
+        password: 'Password must contain at least one lowercase character',
+        confirmPassword: ''
+      }
+    });
+
+    render(withIntl(<SignUpForm />));
+
+    await userEvent.type(screen.getByLabelText('Email'), 'user@example.com');
+    await userEvent.type(screen.getByLabelText('Password'), '12345678');
+    await userEvent.type(screen.getByLabelText('Confirm Password'), '12345678');
+    await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    expect(await screen.findByText('Validation failed')).toBeInTheDocument();
+    expect(mockSignUpAction).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Email')).toHaveValue('user@example.com');
+    expect(screen.getByLabelText('Password')).toHaveValue('12345678');
+    expect(screen.getByLabelText('Confirm Password')).toHaveValue('12345678');
+
+    fireEvent.submit(screen.getByTestId('sign-up-form').querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockSignUpAction).toHaveBeenCalledTimes(2);
+    });
+
+    await userEvent.type(screen.getByLabelText('Password'), 'a');
+
+    expect(
+      screen.queryByText(
+        'Password must contain at least one lowercase character'
+      )
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Validation failed')).not.toBeInTheDocument();
+  });
+
+  it('keeps login values and clears the stale error when a field changes', async () => {
+    mockAuthenticateAction.mockResolvedValue('Invalid email or password');
+
+    render(withIntl(<LoginForm />));
+
+    await userEvent.type(screen.getByLabelText('Email'), 'user@example.com');
+    await userEvent.type(screen.getByLabelText('Password'), '12345678');
+    await userEvent.click(screen.getByRole('button', { name: /log in/i }));
+
+    expect(
+      await screen.findByText('Invalid email or password')
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toHaveValue('user@example.com');
+    expect(screen.getByLabelText('Password')).toHaveValue('12345678');
+
+    await userEvent.type(screen.getByLabelText('Email'), 'x');
+
+    expect(
+      screen.queryByText('Invalid email or password')
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps forgot-password email and clears the stale response when edited', async () => {
+    render(withIntl(<ForgotPasswordForm />));
+
+    await userEvent.type(screen.getByLabelText('Email'), 'user@example.com');
+    await userEvent.click(
+      screen.getByRole('button', { name: /send reset link/i })
+    );
+
+    expect(await screen.findByText('Reset link sent')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toHaveValue('user@example.com');
+
+    await userEvent.type(screen.getByLabelText('Email'), 'x');
+
+    expect(screen.queryByText('Reset link sent')).not.toBeInTheDocument();
+  });
+
+  it('keeps new-password values and clears stale field validation when edited', async () => {
+    mockCreateNewPasswordAction.mockResolvedValue({
+      ok: false,
+      message: 'Validation failed',
+      validationErrors: {
+        newPassword: 'Password must contain at least one lowercase character'
+      }
+    });
+
+    const { container } = render(
+      withIntl(<CreateNewPasswordForm userId={1} token="token" />)
+    );
+
+    await userEvent.type(screen.getByLabelText('New Password'), '12345678');
+    await userEvent.type(
+      screen.getByLabelText('Confirm New Password'),
+      '12345678'
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: /reset password/i })
+    );
+
+    await waitFor(() => {
+      expect(mockCreateNewPasswordAction).toHaveBeenCalled();
+    });
+    expect(mockCreateNewPasswordAction).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('New Password')).toHaveValue('12345678');
+    expect(screen.getByLabelText('Confirm New Password')).toHaveValue(
+      '12345678'
+    );
+
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockCreateNewPasswordAction).toHaveBeenCalledTimes(2);
+    });
+
+    await userEvent.type(screen.getByLabelText('New Password'), 'a');
+
+    expect(
+      screen.queryByText(
+        'Password must contain at least one lowercase character'
+      )
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Validation failed')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/auth/create-new-password-form.tsx
+++ b/client/src/components/auth/create-new-password-form.tsx
@@ -14,8 +14,10 @@ import {
   CheckCircleIcon,
   ExclamationCircleIcon
 } from '@heroicons/react/24/outline';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { ArrowRightIcon } from '@heroicons/react/20/solid';
-import { useActionState } from 'react';
+import type { FormEvent } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { ActionResponseModel } from '@/lib/types/action';
@@ -27,19 +29,58 @@ type Props = {
   token: string;
 };
 
+const initialFormValues = {
+  newPassword: '',
+  confirmedNewPassword: ''
+};
+
+type CreateNewPasswordFormModel = typeof initialFormValues;
+
 export default function CreateNewPasswordForm({ userId, token }: Props) {
   const t = useTranslations('create_new_password.form');
-  const [response, formAction, isPending] = useActionState(
-    (prevState: ActionResponseModel | undefined, formData: FormData) => {
-      const newFormData = new FormData();
-      formData.forEach((value, key) => newFormData.append(key, value));
-      newFormData.append('userId', String(userId));
-      newFormData.append('token', token);
+  const {
+    register,
+    handleSubmit,
+    clearErrors,
+    setError,
+    formState: { errors, isSubmitting }
+  } = useForm<CreateNewPasswordFormModel>({
+    defaultValues: initialFormValues
+  });
+  const [response, setResponse] = useState<ActionResponseModel>();
 
-      return createNewPasswordAction(prevState, newFormData);
-    },
-    undefined
-  );
+  const clearFieldState = (field: keyof CreateNewPasswordFormModel) => {
+    clearErrors(field);
+    setResponse(undefined);
+  };
+
+  const onSubmit: SubmitHandler<CreateNewPasswordFormModel> = async (data) => {
+    setResponse(undefined);
+
+    const formData = new FormData();
+    formData.append('newPassword', data.newPassword);
+    formData.append('confirmedNewPassword', data.confirmedNewPassword);
+    formData.append('userId', String(userId));
+    formData.append('token', token);
+
+    const actionResponse = await createNewPasswordAction(undefined, formData);
+    setResponse(actionResponse);
+
+    if (!actionResponse.ok && actionResponse.validationErrors) {
+      Object.entries(actionResponse.validationErrors).forEach(
+        ([key, value]) => {
+          setError(key as keyof CreateNewPasswordFormModel, { message: value });
+        }
+      );
+    }
+  };
+
+  const handleFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    clearErrors();
+    setResponse(undefined);
+
+    return handleSubmit(onSubmit)(event);
+  };
 
   return (
     <Card
@@ -50,33 +91,37 @@ export default function CreateNewPasswordForm({ userId, token }: Props) {
         <h1 className="text-3xl font-medium">{t('title')}</h1>
       </CardHeader>
       <CardBody className="p-8 pb-0">
-        <form action={formAction} className="flex flex-col gap-4">
+        <form onSubmit={handleFormSubmit} className="flex flex-col gap-4">
           <Input
+            {...register('newPassword', {
+              onChange: () => clearFieldState('newPassword')
+            })}
             labelPlacement="outside"
             variant="faded"
             id="newPassword"
             type="password"
-            name="newPassword"
             label={t('new_password')}
             placeholder={t('new_password_placeholder')}
-            isInvalid={!!response?.validationErrors?.newPassword}
-            errorMessage={response?.validationErrors?.newPassword}
+            isInvalid={!!errors.newPassword}
+            errorMessage={errors.newPassword?.message}
           />
           <Input
+            {...register('confirmedNewPassword', {
+              onChange: () => clearFieldState('confirmedNewPassword')
+            })}
             labelPlacement="outside"
             variant="faded"
             id="confirmedNewPassword"
             type="password"
-            name="confirmedNewPassword"
             label={t('confirmed_new_password')}
             placeholder={t('confirmed_new_password_placeholder')}
-            isInvalid={!!response?.validationErrors?.confirmedNewPassword}
-            errorMessage={response?.validationErrors?.confirmedNewPassword}
+            isInvalid={!!errors.confirmedNewPassword}
+            errorMessage={errors.confirmedNewPassword?.message}
           />
           <Button
             className="w-full justify-between"
-            aria-disabled={isPending}
-            isLoading={isPending}
+            aria-disabled={isSubmitting}
+            isLoading={isSubmitting}
             type="submit"
             endContent={<ArrowRightIcon className="h-5 w-5" />}
             color="secondary"

--- a/client/src/components/auth/forgot-password-form.tsx
+++ b/client/src/components/auth/forgot-password-form.tsx
@@ -15,20 +15,44 @@ import {
   CheckCircleIcon,
   ExclamationCircleIcon
 } from '@heroicons/react/24/outline';
-import { useActionState } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
+import type { FormEvent } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { FORGOT_PASSWORD_PAGE, SIGN_UP_PAGE } from '@/lib/constants/pages';
 import { ActionResponseModel } from '@/lib/types/action';
 import { resetPasswordAction } from '@/lib/actions';
 
+type ForgotPasswordFormModel = {
+  email: string;
+};
+
 export default function ForgotPasswordForm() {
   const t = useTranslations('forgot_password');
-  const [response, formAction, isPending] = useActionState(
-    (prevState: ActionResponseModel | undefined, formData: FormData) =>
-      resetPasswordAction(prevState, formData.get('email') as string),
-    undefined
-  );
+  const {
+    register,
+    handleSubmit,
+    clearErrors,
+    formState: { errors, isSubmitting }
+  } = useForm<ForgotPasswordFormModel>({
+    defaultValues: {
+      email: ''
+    }
+  });
+  const [response, setResponse] = useState<ActionResponseModel>();
+
+  const onSubmit: SubmitHandler<ForgotPasswordFormModel> = async (data) => {
+    setResponse(undefined);
+    setResponse(await resetPasswordAction(undefined, data.email));
+  };
+
+  const handleFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    clearErrors();
+    setResponse(undefined);
+
+    return handleSubmit(onSubmit)(event);
+  };
 
   return (
     <Card
@@ -39,19 +63,26 @@ export default function ForgotPasswordForm() {
         <h1 className="text-3xl font-medium">{t('card_header')}</h1>
       </CardHeader>
       <CardBody className="p-8 pb-0">
-        <form action={formAction} className="flex flex-col gap-4">
+        <form onSubmit={handleFormSubmit} className="flex flex-col gap-4">
           <Input
+            {...register('email', {
+              onChange: () => {
+                clearErrors('email');
+                setResponse(undefined);
+              }
+            })}
             labelPlacement="outside"
             variant="faded"
             id="email"
-            name="email"
             label={t('email')}
             placeholder={t('email_placeholder')}
+            isInvalid={!!errors.email}
+            errorMessage={errors.email?.message}
           />
           <Button
             className="w-full justify-between"
-            aria-disabled={isPending}
-            isLoading={isPending}
+            aria-disabled={isSubmitting}
+            isLoading={isSubmitting}
             type="submit"
             endContent={<ArrowRightIcon className="h-5 w-5" />}
             color="secondary"

--- a/client/src/components/auth/login-form.tsx
+++ b/client/src/components/auth/login-form.tsx
@@ -9,20 +9,53 @@ import {
   Input,
   Link
 } from '@heroui/react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { ArrowRightIcon } from '@heroicons/react/20/solid';
 import { ExclamationCircleIcon } from '@heroicons/react/24/outline';
-import { useActionState } from 'react';
+import type { FormEvent } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { FORGOT_PASSWORD_PAGE, SIGN_UP_PAGE } from '@/lib/constants/pages';
 import { authenticateAction } from '@/lib/actions';
 
+type LoginFormModel = {
+  email: string;
+  password: string;
+};
+
 export default function LoginForm() {
   const t = useTranslations('login.form');
-  const [errorMessage, formAction, isPending] = useActionState(
-    authenticateAction,
-    undefined
-  );
+  const {
+    register,
+    handleSubmit,
+    clearErrors,
+    formState: { errors, isSubmitting }
+  } = useForm<LoginFormModel>({
+    defaultValues: {
+      email: '',
+      password: ''
+    }
+  });
+  const [errorMessage, setErrorMessage] = useState<string>();
+
+  const onSubmit: SubmitHandler<LoginFormModel> = async (data) => {
+    setErrorMessage(undefined);
+
+    const formData = new FormData();
+    formData.append('email', data.email);
+    formData.append('password', data.password);
+
+    const response = await authenticateAction(undefined, formData);
+    setErrorMessage(response);
+  };
+
+  const handleFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    clearErrors();
+    setErrorMessage(undefined);
+
+    return handleSubmit(onSubmit)(event);
+  };
 
   return (
     <Card
@@ -33,28 +66,42 @@ export default function LoginForm() {
         <h1 className="text-3xl font-medium">{t('title')}</h1>
       </CardHeader>
       <CardBody className="p-8 pb-0">
-        <form action={formAction} className="flex flex-col gap-4">
+        <form onSubmit={handleFormSubmit} className="flex flex-col gap-4">
           <Input
+            {...register('email', {
+              onChange: () => {
+                clearErrors('email');
+                setErrorMessage(undefined);
+              }
+            })}
             labelPlacement="outside"
             variant="faded"
             id="email"
-            name="email"
             label={t('email')}
             placeholder={t('email_placeholder')}
+            isInvalid={!!errors.email}
+            errorMessage={errors.email?.message}
           />
           <Input
+            {...register('password', {
+              onChange: () => {
+                clearErrors('password');
+                setErrorMessage(undefined);
+              }
+            })}
             labelPlacement="outside"
             variant="faded"
             id="password"
             type="password"
-            name="password"
             label={t('password')}
             placeholder={t('password_placeholder')}
+            isInvalid={!!errors.password}
+            errorMessage={errors.password?.message}
           />
           <Button
             className="w-full justify-between"
-            aria-disabled={isPending}
-            isLoading={isPending}
+            aria-disabled={isSubmitting}
+            isLoading={isSubmitting}
             type="submit"
             endContent={<ArrowRightIcon className="h-5 w-5" />}
             color="secondary"

--- a/client/src/components/auth/sign-up-form.tsx
+++ b/client/src/components/auth/sign-up-form.tsx
@@ -13,38 +13,88 @@ import {
   CheckCircleIcon,
   ExclamationCircleIcon
 } from '@heroicons/react/24/outline';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { ArrowRightIcon } from '@heroicons/react/20/solid';
-import { useActionState } from 'react';
+import type { FormEvent } from 'react';
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { LOGIN_PAGE } from '@/lib/constants/pages';
 import { signUpAction } from '@/lib/actions';
 
-const initialState = {
+type SignUpFormModel = {
+  email: string;
+  password: string;
+  confirmPassword: string;
+};
+
+const initialSubmissionMessage = {
   message: '',
-  errors: {
-    email: '',
-    password: '',
-    confirmPassword: ''
-  },
   ok: false
 };
 
+type SubmissionMessage = typeof initialSubmissionMessage | null;
+
 export default function SignUpForm() {
   const t = useTranslations('sign_up.form');
-  const [state, formAction, isPending] = useActionState(
-    signUpAction,
-    initialState
-  );
+  const {
+    register,
+    handleSubmit,
+    clearErrors,
+    setError,
+    formState: { errors, isSubmitting }
+  } = useForm<SignUpFormModel>({
+    defaultValues: {
+      email: '',
+      password: '',
+      confirmPassword: ''
+    }
+  });
+  const [submissionMessage, setSubmissionMessage] =
+    useState<SubmissionMessage>(null);
+
+  const clearFieldState = (field: keyof SignUpFormModel) => {
+    clearErrors(field);
+    setSubmissionMessage(null);
+  };
+
+  const onSubmit: SubmitHandler<SignUpFormModel> = async (data) => {
+    setSubmissionMessage(null);
+
+    const formData = new FormData();
+    formData.append('email', data.email);
+    formData.append('password', data.password);
+    formData.append('confirm-password', data.confirmPassword);
+
+    const response = await signUpAction(initialSubmissionMessage, formData);
+    if (response?.ok === false) {
+      Object.entries(response.errors || {}).forEach(([key, value]) => {
+        if (!value) return;
+
+        setError(key as keyof SignUpFormModel, { message: value });
+      });
+      setSubmissionMessage({
+        message: response.message || '',
+        ok: false
+      });
+    }
+  };
+
+  const handleFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    clearErrors();
+    setSubmissionMessage(null);
+
+    return handleSubmit(onSubmit)(event);
+  };
 
   const renderSubmissionMessage = () => {
-    if (!state?.message) return null;
+    if (!submissionMessage?.message) return null;
 
-    if (!state.ok) {
+    if (!submissionMessage.ok) {
       return (
         <div className="mb-6 flex items-center gap-1">
           <ExclamationCircleIcon className="text-danger-500 h-5 w-5" />
-          <p className="text-danger-500 text-sm">{state.message}</p>
+          <p className="text-danger-500 text-sm">{submissionMessage.message}</p>
         </div>
       );
     }
@@ -52,7 +102,7 @@ export default function SignUpForm() {
     return (
       <div className="mb-6 flex items-center gap-1">
         <CheckCircleIcon className="text-success-500 h-5 w-5" />
-        <p className="text-success-500 text-sm">{state.message}</p>
+        <p className="text-success-500 text-sm">{submissionMessage.message}</p>
       </div>
     );
   };
@@ -67,44 +117,50 @@ export default function SignUpForm() {
         <h1 className="text-3xl font-medium">{t('title')}</h1>
       </CardHeader>
       <CardBody className="p-8 pb-0">
-        <form action={formAction} className="flex flex-col gap-4">
+        <form onSubmit={handleFormSubmit} className="flex flex-col gap-4">
           <Input
+            {...register('email', {
+              onChange: () => clearFieldState('email')
+            })}
             labelPlacement="outside"
             variant="faded"
             id="email"
-            name="email"
             label={t('email')}
             placeholder={t('email_placeholder')}
-            isInvalid={!!state.errors?.email}
-            errorMessage={state.errors?.email}
+            isInvalid={!!errors.email}
+            errorMessage={errors.email?.message}
           />
           <Input
+            {...register('password', {
+              onChange: () => clearFieldState('password')
+            })}
             labelPlacement="outside"
             variant="faded"
             id="password"
             type="password"
-            name="password"
             label={t('password')}
             placeholder={t('password_placeholder')}
-            isInvalid={!!state.errors?.password}
-            errorMessage={state.errors?.password}
+            isInvalid={!!errors.password}
+            errorMessage={errors.password?.message}
           />
           <Input
+            {...register('confirmPassword', {
+              onChange: () => clearFieldState('confirmPassword')
+            })}
             labelPlacement="outside"
             variant="faded"
             id="confirm-password"
             type="password"
-            name="confirm-password"
             label={t('confirm_password')}
             placeholder={t('confirm_password_placeholder')}
-            isInvalid={!!state.errors?.confirmPassword}
-            errorMessage={state.errors?.confirmPassword}
+            isInvalid={!!errors.confirmPassword}
+            errorMessage={errors.confirmPassword?.message}
           />
           <Button
             className="w-full justify-between"
-            aria-disabled={isPending}
+            aria-disabled={isSubmitting}
             type="submit"
-            isLoading={isPending}
+            isLoading={isSubmitting}
             endContent={<ArrowRightIcon className="h-5 w-5" />}
             color="secondary"
           >


### PR DESCRIPTION
### Overview
Fixes the signup validation bug and normalizes auth form submission state handling.

- Replaces auth useActionState forms with the existing react-hook-form pattern used elsewhere in the app.
- Preserves typed values after server validation responses across signup, login, forgot password, and reset-password forms.
- Clears stale RHF errors and response messages before resubmitting, so repeated submits still call the server action.
- Adds auth form regression coverage for value preservation, stale error clearing, and resubmitting after validation errors.

Refs REK-73