### PR TITLE
[REK-54] Forward contact emails through Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,8 @@ STRIPE_EUR_ANNUAL_PRICE=
 # Email
 RESEND_EMAIL_API_KEY=
 RESEND_FROM_EMAIL="InvoiceTrackr <noreply@invoicetrackr.app>"
-RESEND_FORWARD_TO_EMAIL=johndoe@gmail.com
-RESEND_FORWARD_FROM_EMAIL=noreply@invoicetrackr.app
+RESEND_FORWARD_TO_EMAIL=owner@example.com
+RESEND_FORWARD_FROM_EMAIL=support@invoicetrackr.app
 
 # Analytics
 NEXT_PUBLIC_POSTHOG_KEY=

--- a/client/src/app/privacy-policy/privacy-policy-page-content.tsx
+++ b/client/src/app/privacy-policy/privacy-policy-page-content.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from 'next-intl';
 
 const LAST_UPDATED = '10/30/2025';
-const CONTACT_EMAIL = 'invoicetrackr@gmail.com';
+const CONTACT_EMAIL = 'support@invoicetrackr.app';
 
 export default function PrivacyPolicyPageContent() {
   const t = useTranslations('privacy_policy');

--- a/client/src/app/terms-of-service/terms-of-service-page-content.tsx
+++ b/client/src/app/terms-of-service/terms-of-service-page-content.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from 'next-intl';
 
 const LAST_UPDATED = '10/30/2025';
-const CONTACT_EMAIL = 'invoicetrackr@gmail.com';
+const CONTACT_EMAIL = 'support@invoicetrackr.app';
 
 export default function TermsOfServicePageContent() {
   const t = useTranslations('terms_of_service');

--- a/client/src/components/layout/contact-form-dialog.tsx
+++ b/client/src/components/layout/contact-form-dialog.tsx
@@ -35,6 +35,8 @@ export default function ContactFormDialog() {
   const [isOpen, setIsOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
+  const openDialog = () => setIsOpen(true);
+
   const handleClose = () => {
     setIsOpen(false);
     reset();
@@ -65,50 +67,52 @@ export default function ContactFormDialog() {
 
   return (
     <>
-      <Button onPress={() => setIsOpen(true)} className="max-w-min">
+      <Button type="button" onPress={openDialog} className="max-w-min">
         {t('title')}
       </Button>
 
-      <Modal>
-        <Modal.Backdrop
-          isOpen={isOpen}
-          onOpenChange={(open) => !open && handleClose()}
-        >
+      <Modal isOpen={isOpen} onOpenChange={(open) => !open && handleClose()}>
+        <Modal.Backdrop>
           <Modal.Container size="lg">
             <Modal.Dialog>
               <Modal.CloseTrigger />
-        <Form onSubmit={handleSubmit(onSubmit)}>
-          <Modal.Header>
-            <Modal.Heading>{t('title')}</Modal.Heading>
-          </Modal.Header>
-          <Modal.Body className="w-full flex-col">
-            <TextField variant="secondary" isInvalid={!!errors.email}>
-              <Label>{t('email_label')}</Label>
-              <Input
-                {...register('email')}
-                placeholder={t('email_placeholder')}
-              />
-              <FieldError>{errors.email?.message}</FieldError>
-            </TextField>
-            <TextField variant="secondary" isInvalid={!!errors.message}>
-              <Label>{t('message_label')}</Label>
-              <TextArea
-                {...register('message')}
-                placeholder={t('message_placeholder')}
-                maxLength={5000}
-              />
-              <FieldError>{errors.message?.message}</FieldError>
-            </TextField>
-          </Modal.Body>
-          <Modal.Footer className="w-full">
-            <Button variant="outline" onPress={handleClose}>
-              {t('cancel')}
-            </Button>
-            <Button isPending={isPending} type="submit">
-              {t('send')}
-            </Button>
-          </Modal.Footer>
-        </Form>
+              <Form onSubmit={handleSubmit(onSubmit)}>
+                <Modal.Header>
+                  <Modal.Heading>{t('title')}</Modal.Heading>
+                </Modal.Header>
+                <Modal.Body className="flex w-full flex-col gap-3">
+                  <TextField variant="secondary" isInvalid={!!errors.email}>
+                    <Label>{t('email_label')}</Label>
+                    <Input
+                      {...register('email')}
+                      placeholder={t('email_placeholder')}
+                    />
+                    <FieldError>{errors.email?.message}</FieldError>
+                  </TextField>
+                  <TextField variant="secondary" isInvalid={!!errors.message}>
+                    <Label>{t('message_label')}</Label>
+                    <TextArea
+                      {...register('message')}
+                      placeholder={t('message_placeholder')}
+                      maxLength={5000}
+                    />
+                    <FieldError>{errors.message?.message}</FieldError>
+                  </TextField>
+                </Modal.Body>
+                <Modal.Footer className="w-full">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    isDisabled={isPending}
+                    onPress={handleClose}
+                  >
+                    {t('cancel')}
+                  </Button>
+                  <Button isPending={isPending} type="submit">
+                    {t('send')}
+                  </Button>
+                </Modal.Footer>
+              </Form>
             </Modal.Dialog>
           </Modal.Container>
         </Modal.Backdrop>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,8 +219,8 @@ importers:
         specifier: ^8.16.3
         version: 8.16.3
       resend:
-        specifier: ^6.4.2
-        version: 6.4.2(@react-email/render@2.0.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        specifier: ^6.15.0
+        version: 6.15.0(@react-email/render@2.0.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       stripe:
         specifier: ^22.2.2
         version: 22.2.2(@types/node@22.19.1)
@@ -2997,10 +2997,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-tree@3.1.0:
-    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
-    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
-
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -3336,9 +3332,6 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
-
-  es6-promise@4.2.8:
-    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -4219,9 +4212,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mdn-data@2.12.2:
-    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
-
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -4635,6 +4625,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
@@ -4808,9 +4801,6 @@ packages:
 
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
-  querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -4966,12 +4956,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-
-  resend@6.4.2:
-    resolution: {integrity: sha512-YnxmwneltZtjc7Xff+8ZjG1/xPLdstCiqsedgO/JxWTf7vKRAPCx6CkhQ3ZXskG0mrmf8+I5wr/wNRd8PQMUfw==}
-    engines: {node: '>=18'}
+  resend@6.15.0:
+    resolution: {integrity: sha512-xU9p2kK0nM1l7eM3FKqA6ZNSdR6ZfOHx/1Os4mrX/gwdQQhDpBNcQY6quJIiT5+MQTMykvCGQOb2MwPxloa5gA==}
+    engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
     peerDependenciesMeta:
@@ -5181,6 +5168,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -5284,9 +5274,6 @@ packages:
 
   svg-arc-to-cubic-bezier@3.2.0:
     resolution: {integrity: sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==}
-
-  svix@1.76.1:
-    resolution: {integrity: sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -5512,9 +5499,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
-
   use-intl@4.4.0:
     resolution: {integrity: sha512-smFekJWtokDRBLC5/ZumlBREzdXOkw06+56Ifj2uRe9266Mk+yWQm2PcJO+EwlOE5sHIXHixOTzN6V8E0RGUbw==}
     peerDependencies:
@@ -5527,11 +5511,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -5808,7 +5787,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.2.2
 
@@ -8176,11 +8155,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-tree@3.1.0:
-    dependencies:
-      mdn-data: 2.12.2
-      source-map-js: 1.2.1
-
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -8192,7 +8166,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 4.0.5
       '@csstools/css-syntax-patches-for-csstree': 1.0.16
-      css-tree: 3.1.0
+      css-tree: 3.2.1
 
   csstype@3.2.3: {}
 
@@ -8487,8 +8461,6 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
-
-  es6-promise@4.2.8: {}
 
   esbuild-register@3.6.0(esbuild@0.19.12):
     dependencies:
@@ -9623,8 +9595,6 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdn-data@2.12.2: {}
-
   mdn-data@2.27.1: {}
 
   media-engine@1.0.3: {}
@@ -10011,6 +9981,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
@@ -10114,8 +10086,6 @@ snapshots:
   punycode@2.3.1: {}
 
   q@1.5.1: {}
-
-  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -10341,11 +10311,10 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  requires-port@1.0.0: {}
-
-  resend@6.4.2(@react-email/render@2.0.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+  resend@6.15.0(@react-email/render@2.0.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
     dependencies:
-      svix: 1.76.1
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
     optionalDependencies:
       '@react-email/render': 2.0.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
@@ -10626,6 +10595,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -10738,15 +10712,6 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-arc-to-cubic-bezier@3.2.0: {}
-
-  svix@1.76.1:
-    dependencies:
-      '@stablelib/base64': 1.0.1
-      '@types/node': 22.19.1
-      es6-promise: 4.2.8
-      fast-sha256: 1.3.0
-      url-parse: 1.5.10
-      uuid: 10.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -11003,11 +10968,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-parse@1.5.10:
-    dependencies:
-      querystringify: 2.2.0
-      requires-port: 1.0.0
-
   use-intl@4.4.0(react@19.2.7):
     dependencies:
       '@formatjs/fast-memoize': 2.2.7
@@ -11020,8 +10980,6 @@ snapshots:
       react: 19.2.7
 
   util-deprecate@1.0.2: {}
-
-  uuid@10.0.0: {}
 
   vary@1.1.2: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
     "fastify-raw-body": "^5.0.0",
     "fastify-type-provider-zod": "^6.1.0",
     "pg": "^8.16.3",
-    "resend": "^6.4.2",
+    "resend": "^6.15.0",
     "stripe": "^22.2.2",
     "ws": "^8.18.3"
   },

--- a/server/src/controllers/__tests__/contact.ts
+++ b/server/src/controllers/__tests__/contact.ts
@@ -9,6 +9,7 @@ vi.mock('../../config/resend');
 describe('Contact Controller', () => {
   describe('POST /api/contact', () => {
     it('should send contact message successfully', async () => {
+      process.env.RESEND_FORWARD_TO_EMAIL = 'owner@example.com';
       vi.mocked(resend.emails.send).mockResolvedValue({
         data: { id: 'test-email-id' },
         headers: null,
@@ -35,9 +36,10 @@ describe('Contact Controller', () => {
       expect(body.message).toBeDefined();
       expect(resend.emails.send).toHaveBeenCalledWith({
         from: 'InvoiceTrackr <noreply@invoicetrackr.app>',
-        to: 'support@ruwhia8088.resend.app',
+        to: 'owner@example.com',
         subject: 'New Contact Message',
-        react: expect.anything()
+        react: expect.anything(),
+        replyTo: 'test@example.com'
       });
 
       await app.close();

--- a/server/src/controllers/__tests__/webhook.ts
+++ b/server/src/controllers/__tests__/webhook.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { createTestApp } from '../../test/app';
-import { mockResendForward } from '../../test/setup';
 import { handleResendWebhook } from '../webhook';
+import { mockResendForward } from '../../test/setup';
 
 describe('Webhook Controller', () => {
   describe('POST /api/webhook/resend', () => {

--- a/server/src/controllers/__tests__/webhook.ts
+++ b/server/src/controllers/__tests__/webhook.ts
@@ -1,15 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { createTestApp } from '../../test/app';
-import { handleResendWebhook } from '../webhook';
 import { mockResendForward } from '../../test/setup';
+import { handleResendWebhook } from '../webhook';
 
 describe('Webhook Controller', () => {
   describe('POST /api/webhook/resend', () => {
-    it('forwards received emails to the configured inbox', async () => {
-      process.env.RESEND_FORWARD_TO_EMAIL = 'reko.jsx@gmail.com';
-      process.env.RESEND_FORWARD_FROM_EMAIL = 'noreply@invoicetrackr.app';
+    beforeEach(() => {
+      process.env.RESEND_FORWARD_TO_EMAIL = 'owner@example.com';
+      process.env.RESEND_FORWARD_FROM_EMAIL = 'support@invoicetrackr.app';
+    });
 
+    it('forwards received emails to the configured inbox', async () => {
       const app = await createTestApp((fastifyApp) => {
         fastifyApp.post('/api/webhook/resend', handleResendWebhook);
       });
@@ -28,8 +30,8 @@ describe('Webhook Controller', () => {
       expect(response.statusCode).toBe(200);
       expect(mockResendForward).toHaveBeenCalledWith({
         emailId: 'eml_received_123',
-        to: 'reko.jsx@gmail.com',
-        from: 'noreply@invoicetrackr.app'
+        to: 'owner@example.com',
+        from: 'support@invoicetrackr.app'
       });
 
       await app.close();
@@ -79,6 +81,7 @@ describe('Webhook Controller', () => {
       });
 
       expect(response.statusCode).toBe(500);
+      expect(JSON.parse(response.body).message).toBe('Forward failed');
 
       await app.close();
     });

--- a/server/src/controllers/contact.ts
+++ b/server/src/controllers/contact.ts
@@ -19,12 +19,18 @@ export const postContactMessage = async (
     email,
     message
   });
+  const contactToEmail = process.env.RESEND_FORWARD_TO_EMAIL;
+
+  if (!contactToEmail) {
+    throw new BadRequestError(i18n.t('error.contact.unableToSendMessage'));
+  }
 
   const { error } = await resend.emails.send({
     from: appEmailFrom,
-    to: 'support@ruwhia8088.resend.app',
+    to: contactToEmail,
     subject: 'New Contact Message',
-    react: emailHtml
+    react: emailHtml,
+    replyTo: email
   });
 
   if (error) {

--- a/server/src/controllers/webhook.ts
+++ b/server/src/controllers/webhook.ts
@@ -23,21 +23,12 @@ import { stripe } from '../config/stripe';
 import { syncSubscriptionInDb } from './payment';
 
 const GRACE_PERIOD_DAYS = 3;
-const DEFAULT_FORWARD_TO_EMAIL = 'reko.jsx@gmail.com';
-const DEFAULT_FORWARD_FROM_EMAIL = 'noreply@invoicetrackr.app';
+const DEFAULT_FORWARD_FROM_EMAIL = 'support@invoicetrackr.app';
 const locales = { en, lt };
 
 type ResendForwardResponse = {
   data: unknown;
   error: { message: string } | null;
-};
-
-type ResendReceiving = typeof resend.emails.receiving & {
-  forward: (payload: {
-    emailId: string;
-    to: string;
-    from: string;
-  }) => Promise<ResendForwardResponse>;
 };
 
 const getCustomerId = (
@@ -47,16 +38,20 @@ const getCustomerId = (
 const forwardReceivedEmail = async (
   emailId: string
 ): Promise<ResendForwardResponse> => {
-  const receiving = resend.emails.receiving as ResendReceiving;
-  const to = process.env.RESEND_FORWARD_TO_EMAIL || DEFAULT_FORWARD_TO_EMAIL;
+  const to = process.env.RESEND_FORWARD_TO_EMAIL!;
   const from =
     process.env.RESEND_FORWARD_FROM_EMAIL || DEFAULT_FORWARD_FROM_EMAIL;
 
-  return receiving.forward({
+  const { data, error } = await resend.emails.receiving.forward({
     emailId,
     to,
     from
   });
+
+  return {
+    data,
+    error: error ? { message: error.message } : null
+  };
 };
 
 const sendBillingEmail = async ({


### PR DESCRIPTION
### Overview

Updates the REK-54 Resend email flow after local verification:

- forwards received Resend inbound emails through the SDK helper now available in the upgraded Resend package
- sends contact form messages to the configured contact inbox instead of the temporary Resend address
- sets the contact form reply-to to the visitor email and keeps the modal stable while submit is pending
- updates public support email references and related tests

I did not run tests per the repository workflow; the contact form was verified locally after adding the required contact destination env var.
