### PR TITLE
[REK-60] Improve free invoice funnel

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -1345,8 +1345,23 @@
                 "no_bank_accounts": "You have no bank accounts. Create one to get started."
             },
             "free_invoice": {
-                "title": "Create Invoice",
-                "description": "Create, preview and download an invoice for free"
+                "eyebrow": "Free invoice generator",
+                "title": "Create a polished PDF invoice without signing up",
+                "description": "Build a real invoice, preview the PDF, and download it for free. When you are ready to run the full workflow, start a 7-day trial to save, send, track, and reuse everything.",
+                "benefits": [
+                    "Professional English or Lithuanian PDF output",
+                    "VAT/PVM-ready line items and totals",
+                    "No account required for one-off PDF downloads"
+                ],
+                "upgrade_title": "Need more than a PDF?",
+                "upgrade_description": "Create an account to save invoices, reuse clients and bank accounts, send secure links, and track payment status.",
+                "upgrade_cta": "Start 7-day trial",
+                "actions_title": "Preview the invoice before downloading.",
+                "actions_description": "The PDF download stays free. Trial features are for saving, sending, history, reminders, and payment tracking.",
+                "start_trial_cta": "Save and send with trial",
+                "modal_cta_title": "Want to save, send, and track invoices?",
+                "modal_cta_description": "Start a 7-day trial to manage real client workflows instead of downloading one PDF at a time.",
+                "modal_cta_button": "Start trial"
             },
             "services_heading": "Services",
             "signature_heading": "Signature",

--- a/client/messages/lt.json
+++ b/client/messages/lt.json
@@ -1346,8 +1346,23 @@
                 "no_bank_accounts": "Neturite banko sąskaitų. Sukurkite vieną, kad pradėtumėte."
             },
             "free_invoice": {
-                "title": "Sukurti sąskaitą faktūrą",
-                "description": "Sukurkite, peržiūrėkite ir atsisiųskite sąskaitą faktūrą nemokamai"
+                "eyebrow": "Nemokamas sąskaitos generatorius",
+                "title": "Sukurkite tvarkingą PDF sąskaitą be registracijos",
+                "description": "Paruoškite tikrą sąskaitą, peržiūrėkite PDF ir atsisiųskite nemokamai. Kai reikės pilno darbo proceso, pradėkite 7 dienų bandymą, kad galėtumėte išsaugoti, siųsti, sekti ir naudoti duomenis pakartotinai.",
+                "benefits": [
+                    "Profesionali lietuviška arba angliška PDF sąskaita",
+                    "PVM eilutės ir sumos paruoštos Lietuvos darbui",
+                    "Vienkartiniam PDF atsisiuntimui paskyros nereikia"
+                ],
+                "upgrade_title": "Reikia daugiau nei PDF?",
+                "upgrade_description": "Sukurkite paskyrą, kad galėtumėte išsaugoti sąskaitas, naudoti klientus ir banko sąskaitas pakartotinai, siųsti saugias nuorodas ir sekti apmokėjimą.",
+                "upgrade_cta": "Pradėti 7 dienų bandymą",
+                "actions_title": "Peržiūrėkite sąskaitą prieš atsisiųsdami.",
+                "actions_description": "PDF atsisiuntimas lieka nemokamas. Bandomasis laikotarpis skirtas išsaugojimui, siuntimui, istorijai, priminimams ir mokėjimų sekimui.",
+                "start_trial_cta": "Išsaugoti ir siųsti su bandymu",
+                "modal_cta_title": "Norite išsaugoti, siųsti ir sekti sąskaitas?",
+                "modal_cta_description": "Pradėkite 7 dienų bandymą, kad valdytumėte realius klientų procesus, o ne atsisiųstumėte po vieną PDF.",
+                "modal_cta_button": "Pradėti bandymą"
             },
             "services_heading": "Paslaugos",
             "signature_heading": "Parašas",

--- a/client/src/components/invoice/free-invoice-form.tsx
+++ b/client/src/components/invoice/free-invoice-form.tsx
@@ -1,23 +1,33 @@
 'use client';
 
 import {
+  Alert,
   Button,
   Card,
+  Chip,
   FieldError,
   Input,
   Label,
-  TextField
+  Link,
+  TextField,
+  buttonVariants
 } from '@heroui/react';
+import {
+  ArrowRightIcon,
+  CheckCircleIcon,
+  EyeIcon,
+  PaperAirplaneIcon
+} from '@heroicons/react/24/outline';
 import { type ComponentProps, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import { EyeIcon } from '@heroicons/react/24/outline';
-import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
 import { Currency } from '@/lib/types/currency';
-import { HOME_PAGE } from '@/lib/constants/pages';
 import type { InvoiceBody } from '@invoicetrackr/types';
+import { SIGN_UP_PAGE } from '@/lib/constants/pages';
+import { analyticsEvents } from '@/lib/analytics/events';
 import { calculateInvoiceTotals } from '@/lib/utils';
+import { captureAnalyticsEvent } from '@/lib/analytics/client';
 import { formatDate } from '@/lib/utils/date';
 
 import InvoiceModal from './invoice-modal';
@@ -35,7 +45,6 @@ type Props = {
 const FreeInvoiceForm = ({ language, currency }: Props) => {
   const t = useTranslations('components.invoice_form');
   const pdfTranslator = useTranslations('invoices.pdf');
-  const router = useRouter();
   const methods = useForm<InvoiceBody>({
     defaultValues: {
       sender: {
@@ -81,11 +90,19 @@ const FreeInvoiceForm = ({ language, currency }: Props) => {
     !senderSignature || typeof senderSignature === 'string'
       ? ''
       : URL.createObjectURL(senderSignature);
+  const trialSignupUrl = `${SIGN_UP_PAGE}?trial=true&source=free-invoice`;
 
   const handleSignatureChange = (signature: string | File) => {
     setSenderSignature(signature);
     setValue('senderSignature', signature);
     clearErrors('senderSignature');
+  };
+
+  const handleTrialSignupClick = (source: string) => {
+    captureAnalyticsEvent(analyticsEvents.freeInvoiceSignUpClicked, {
+      source,
+      line_count: getValues('services').length
+    });
   };
 
   const renderTextField = ({
@@ -312,18 +329,81 @@ const FreeInvoiceForm = ({ language, currency }: Props) => {
   );
 
   const renderSubmissionMessageAndActions = () => (
-    <div className="col-span-4 flex w-full items-center justify-between gap-5 overflow-x-hidden">
-      <div className="flex w-full flex-col justify-end gap-1 sm:flex-row">
-        <Button variant="danger-soft" onPress={() => router.push(HOME_PAGE)}>
-          {t('buttons.cancel')}
-        </Button>
-        <Button type="button" onPress={() => setIsInvoiceModalOpen(true)}>
+    <div className="col-span-4 flex w-full flex-col gap-4 border-t pt-6 lg:flex-row lg:items-center lg:justify-between">
+      <div className="max-w-2xl">
+        <p className="text-sm font-medium">{t('free_invoice.actions_title')}</p>
+        <p className="text-muted mt-1 text-sm">
+          {t('free_invoice.actions_description')}
+        </p>
+      </div>
+      <div className="flex w-full flex-col justify-end gap-2 sm:flex-row lg:w-auto">
+        <Button
+          type="button"
+          variant="secondary"
+          className="w-full sm:w-auto"
+          onPress={() => setIsInvoiceModalOpen(true)}
+        >
           <EyeIcon className="h-5 w-5" />
           {t('buttons.preview')}
         </Button>
+        <Link
+          href={trialSignupUrl}
+          onClick={() => handleTrialSignupClick('form_actions')}
+          className={buttonVariants({
+            className: 'w-full justify-center gap-2 sm:w-auto'
+          })}
+        >
+          <PaperAirplaneIcon className="h-5 w-5" />
+          {t('free_invoice.start_trial_cta')}
+        </Link>
       </div>
     </div>
   );
+
+  const renderTrialPrompt = () => (
+    <div className="border-default-200 bg-content1/70 flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <p className="text-sm font-semibold">
+          {t('free_invoice.modal_cta_title')}
+        </p>
+        <p className="text-muted mt-1 text-sm">
+          {t('free_invoice.modal_cta_description')}
+        </p>
+      </div>
+      <Link
+        href={trialSignupUrl}
+        onClick={() => handleTrialSignupClick('preview_modal')}
+        className={buttonVariants({
+          size: 'sm',
+          className: 'shrink-0 gap-2'
+        })}
+      >
+        {t('free_invoice.modal_cta_button')}
+        <ArrowRightIcon className="h-4 w-4" />
+      </Link>
+    </div>
+  );
+
+  const renderBenefits = () => {
+    const benefits = t.raw('free_invoice.benefits') as Array<string>;
+
+    return (
+      <div className="grid gap-3 md:grid-cols-3">
+        {benefits.map((benefit) => (
+          <Alert key={benefit} status="default" className="border px-3 py-1.5">
+            <Alert.Indicator>
+              <CheckCircleIcon className="text-accent h-5 w-5" />
+            </Alert.Indicator>
+            <Alert.Content className="flex-row">
+              <Alert.Title className="text-muted self-center font-normal">
+                {benefit}
+              </Alert.Title>
+            </Alert.Content>
+          </Alert>
+        ))}
+      </div>
+    );
+  };
 
   const getInvoicePreviewData = () => {
     const invoiceTotals = calculateInvoiceTotals(getValues('services'));
@@ -350,12 +430,43 @@ const FreeInvoiceForm = ({ language, currency }: Props) => {
     <>
       <FormProvider {...methods}>
         <div className="mx-auto w-full max-w-7xl px-6 py-8 sm:py-10 md:py-12 lg:py-14">
-          <div className="flex flex-col gap-2">
-            <h1 className="text-3xl font-semibold">
-              {t('free_invoice.title')}
-            </h1>
-            <p className="text-muted">{t('free_invoice.description')}</p>
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(280px,360px)] lg:items-end">
+            <div className="flex max-w-3xl flex-col gap-3">
+              <Chip color="accent" variant="soft" className="w-max">
+                {t('free_invoice.eyebrow')}
+              </Chip>
+              <h1 className="text-3xl font-semibold sm:text-4xl">
+                {t('free_invoice.title')}
+              </h1>
+              <p className="text-muted max-w-2xl">
+                {t('free_invoice.description')}
+              </p>
+            </div>
+            <Card className="parent border p-4">
+              <Card.Header className="flex flex-col items-start gap-1 p-0">
+                <Card.Title className="text-sm font-semibold">
+                  {t('free_invoice.upgrade_title')}
+                </Card.Title>
+                <Card.Description>
+                  {t('free_invoice.upgrade_description')}
+                </Card.Description>
+              </Card.Header>
+              <Card.Footer className="p-0">
+                <Link
+                  href={trialSignupUrl}
+                  onClick={() => handleTrialSignupClick('intro_panel')}
+                  className={buttonVariants({
+                    variant: 'secondary',
+                    className: 'mt-4 w-full justify-between'
+                  })}
+                >
+                  {t('free_invoice.upgrade_cta')}
+                  <ArrowRightIcon className="h-4 w-4" />
+                </Link>
+              </Card.Footer>
+            </Card>
           </div>
+          <div className="mt-6">{renderBenefits()}</div>
           <Card className="mt-8 border bg-transparent p-4 sm:p-8">
             <form
               aria-label={t('a11y.form_label')}
@@ -416,6 +527,7 @@ const FreeInvoiceForm = ({ language, currency }: Props) => {
         invoiceLanguage={language}
         isOpen={isInvoiceModalOpen}
         onOpenChange={setIsInvoiceModalOpen}
+        conversionContent={renderTrialPrompt()}
       />
     </>
   );

--- a/client/src/components/invoice/invoice-modal.tsx
+++ b/client/src/components/invoice/invoice-modal.tsx
@@ -15,7 +15,7 @@ import {
   LanguageIcon,
   XMarkIcon
 } from '@heroicons/react/24/outline';
-import { JSX, useState } from 'react';
+import { JSX, ReactNode, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useTranslations } from 'next-intl';
 
@@ -65,6 +65,7 @@ type Props = {
   pdfUrl?: string | null;
   isPdfDocumentLoading?: boolean;
   showFooterStatus?: boolean;
+  conversionContent?: ReactNode;
 };
 
 const InvoiceModal = ({
@@ -77,7 +78,8 @@ const InvoiceModal = ({
   userPreferredInvoiceLanguage,
   pdfUrl,
   isPdfDocumentLoading,
-  showFooterStatus = false
+  showFooterStatus = false,
+  conversionContent
 }: Props) => {
   const t = useTranslations('invoices.pdf');
   const tTable = useTranslations('invoices.table');
@@ -286,9 +288,12 @@ const InvoiceModal = ({
                 </div>
               </div>
             </div>
-            <footer className="border-default-200 bg-overlay grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-t px-5 py-3 sm:px-6">
-              <div className="text-muted flex min-w-0 items-center gap-2 text-xs">
-                {renderFooterStatus()}
+            <footer className="border-default-200 bg-overlay grid grid-cols-1 items-center gap-4 border-t px-5 py-3 sm:px-6 lg:grid-cols-[minmax(0,1fr)_auto]">
+              <div className="flex min-w-0 flex-col gap-3">
+                <div className="text-muted flex min-w-0 items-center gap-2 text-xs">
+                  {renderFooterStatus()}
+                </div>
+                {conversionContent}
               </div>
               <Button
                 size="sm"

--- a/client/src/components/invoice/invoice-table-cell.tsx
+++ b/client/src/components/invoice/invoice-table-cell.tsx
@@ -247,7 +247,14 @@ const InvoiceTableCell = ({
                     }
                   >
                     {(item) => (
-                      <DropdownItem key={item.uid}>{item.name}</DropdownItem>
+                      <DropdownItem
+                        key={item.uid}
+                        id={item.uid}
+                        textValue={item.name}
+                      >
+                        {item.name}
+                        <Dropdown.ItemIndicator />
+                      </DropdownItem>
                     )}
                   </DropdownMenu>
                 </DropdownPopover>

--- a/client/src/components/layout/contact-form-dialog.tsx
+++ b/client/src/components/layout/contact-form-dialog.tsx
@@ -67,7 +67,7 @@ export default function ContactFormDialog() {
 
   return (
     <>
-      <Button type="button" onPress={openDialog} className="max-w-min">
+      <Button type="button" onPress={openDialog} className="w-full sm:w-auto">
         {t('title')}
       </Button>
 

--- a/client/src/components/signature-pad.tsx
+++ b/client/src/components/signature-pad.tsx
@@ -153,7 +153,7 @@ const SignaturePad = ({
           }
           isDisabled={isReadOnly}
           className={cn(
-            'relative flex h-auto min-h-44 w-full max-w-sm items-center justify-center overflow-hidden border p-6 text-base transition sm:min-h-52',
+            'relative flex h-auto min-h-44 w-full max-w-none items-center justify-center overflow-hidden border p-6 text-base transition sm:min-h-52 sm:max-w-sm',
             {
               'border-danger-soft': isInvalid,
               'hover:border-secondary hover:bg-secondary/5 cursor-pointer':

--- a/client/src/lib/analytics/events.ts
+++ b/client/src/lib/analytics/events.ts
@@ -2,6 +2,7 @@ export const analyticsEvents = {
   landingPageViewed: 'landing_page_viewed',
   pricingViewed: 'pricing_viewed',
   freeInvoiceGeneratorOpened: 'free_invoice_generator_opened',
+  freeInvoiceSignUpClicked: 'free_invoice_sign_up_clicked',
   signUpStarted: 'sign_up_started',
   signUpCompleted: 'sign_up_completed',
   onboardingStepCompleted: 'onboarding_step_completed',


### PR DESCRIPTION
### Overview

Improve the public free invoice generator as an acquisition path without blocking the free PDF workflow.

- Reframe the free generator with clearer value copy, localized EN/LT messaging, and trial CTAs for saved workflows.
- Add a conversion prompt to the invoice preview modal while keeping PDF download available.
- Track free-generator sign-up CTA clicks with source metadata.
- Align the new UI with HeroUI Card, Chip, and Alert patterns.
- Tighten mobile behavior for preview/trial actions, signature capture, and the footer contact button.

### Additional changes

- Fix the invoice-row status dropdown crash by giving status items explicit ids/text values.
- Show the selected status checkmark with `Dropdown.ItemIndicator`, matching the language selector pattern.
- Include the staged unused-import cleanup in the free invoice form.

Checks were not run locally per project handoff preference.