### PR TITLE
[REK-77] Add home animations and public skeletons

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -24,8 +24,10 @@
             "login": "Log In",
             "sign_up": "Sign Up",
             "create_invoice": "Create Invoice",
+            "mobile_menu": "Open menu",
             "features": "Features",
-            "pricing": "Pricing"
+            "pricing": "Pricing",
+            "faq": "FAQ"
         }
     },
     "breadcrumbs": {

--- a/client/messages/lt.json
+++ b/client/messages/lt.json
@@ -24,8 +24,10 @@
             "login": "Prisijungti",
             "sign_up": "Registruotis",
             "create_invoice": "Sukurti sąskaitą faktūrą",
+            "mobile_menu": "Atidaryti meniu",
             "features": "Privalumai",
-            "pricing": "Kainos"
+            "pricing": "Kainos",
+            "faq": "DUK"
         }
     },
     "breadcrumbs": {
@@ -152,9 +154,9 @@
         "hero": {
             "badge_label": "Nauja",
             "badge_text": "Stripe Connect mokėjimai jau veikia",
-            "title": "Išrašykite sąskaitas klientams.",
-            "title_accent": "Gaukite apmokėjimą greičiau.",
-            "subtitle": "Paprastas būdas siųsti sąskaitas, valdyti klientus ir priimti mokėjimus su tvarkingu dokumentu, kurį klientui malonu atsidaryti.",
+            "title": "Sąskaitos klientams.",
+            "title_accent": "Apmokėjimas greičiau.",
+            "subtitle": "Išrašykite sąskaitas, valdykite klientus ir priimkite mokėjimus vienoje aiškioje darbo vietoje.",
             "cta_primary": "Sukurti nemokamą sąskaitą",
             "cta_secondary": "Pradėti Premium",
             "note": "Sugeneruokite sąskaitą be registracijos · 7 dienų Premium bandomasis laikotarpis"

--- a/client/src/app/(auth)/loading.tsx
+++ b/client/src/app/(auth)/loading.tsx
@@ -1,0 +1,5 @@
+import { AuthPageSkeleton } from '@/components/ui/skeletons/public-page-skeletons';
+
+export default function AuthLoading() {
+  return <AuthPageSkeleton />;
+}

--- a/client/src/app/create-invoice/loading.tsx
+++ b/client/src/app/create-invoice/loading.tsx
@@ -1,0 +1,5 @@
+import { CreateInvoicePageSkeleton } from '@/components/ui/skeletons/public-page-skeletons';
+
+export default function CreateInvoiceLoading() {
+  return <CreateInvoicePageSkeleton />;
+}

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -38,7 +38,105 @@
 }
 
 @layer components {
+  html {
+    scroll-behavior: smooth;
+  }
+
   .link {
     @apply no-underline;
+  }
+
+  .landing-reveal {
+    --landing-reveal-start: 0%;
+    --landing-reveal-end: 32%;
+    animation: landing-reveal 700ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-delay: var(--landing-reveal-delay, 0ms);
+    opacity: 0;
+    transform: translateY(18px);
+    will-change: opacity, transform;
+  }
+
+  .landing-hover-lift {
+    transition:
+      border-color 180ms ease,
+      box-shadow 180ms ease,
+      transform 180ms ease;
+  }
+
+  .landing-hover-lift:hover {
+    transform: translateY(-2px);
+  }
+
+  .landing-delay-1 {
+    --landing-reveal-delay: 80ms;
+    --landing-reveal-start: 4%;
+    --landing-reveal-end: 36%;
+  }
+
+  .landing-delay-2 {
+    --landing-reveal-delay: 160ms;
+    --landing-reveal-start: 8%;
+    --landing-reveal-end: 40%;
+  }
+
+  .landing-delay-3 {
+    --landing-reveal-delay: 240ms;
+    --landing-reveal-start: 12%;
+    --landing-reveal-end: 44%;
+  }
+
+  .landing-delay-4 {
+    --landing-reveal-delay: 320ms;
+    --landing-reveal-start: 16%;
+    --landing-reveal-end: 48%;
+  }
+
+  .landing-delay-5 {
+    --landing-reveal-delay: 400ms;
+    --landing-reveal-start: 20%;
+    --landing-reveal-end: 52%;
+  }
+
+  .landing-scroll-reveal {
+    opacity: 0;
+    transform: translateY(18px);
+    will-change: opacity, transform;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+
+    .landing-reveal {
+      animation: none;
+      opacity: 1;
+      transform: none;
+      will-change: auto;
+    }
+
+    .landing-hover-lift,
+    .landing-hover-lift:hover {
+      transform: none;
+      transition: none;
+    }
+
+    .landing-scroll-reveal {
+      opacity: 1;
+      transform: none;
+      will-change: auto;
+    }
+  }
+}
+
+@keyframes landing-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/client/src/app/home/cta.tsx
+++ b/client/src/app/home/cta.tsx
@@ -8,8 +8,11 @@ export default function CTA() {
   const t = useTranslations('home.cta');
 
   return (
-    <section className="mx-auto max-w-5xl px-6 py-24">
-      <Card className="backdrop-blur-xs relative overflow-hidden border bg-transparent p-8 text-center shadow-none sm:p-16">
+    <section id="start" className="mx-auto max-w-5xl scroll-mt-20 px-6 py-24">
+      <Card
+        data-scroll-reveal=""
+        className="landing-scroll-reveal landing-hover-lift backdrop-blur-xs relative overflow-hidden border bg-transparent p-8 text-center shadow-none sm:p-16"
+      >
         <div className="landing-glow-mint text-accent pointer-events-none absolute left-1/2 top-0 h-64 w-full -translate-x-1/2 opacity-25 blur-3xl" />
         <div className="via-accent/50 pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent to-transparent" />
         <Card.Content className="relative p-0">
@@ -26,9 +29,7 @@ export default function CTA() {
           <h2 className="mt-6 text-4xl font-medium tracking-tight md:text-6xl">
             {t('title')}
           </h2>
-          <p className="text-muted mx-auto mt-4 max-w-md">
-            {t('subtitle')}
-          </p>
+          <p className="text-muted mx-auto mt-4 max-w-md">{t('subtitle')}</p>
           <div className="mt-8 flex flex-wrap justify-center gap-3">
             <Link
               href={SIGN_UP_PAGE}

--- a/client/src/app/home/faq.tsx
+++ b/client/src/app/home/faq.tsx
@@ -9,14 +9,15 @@ export default function FAQ() {
   const t = useTranslations('home.faq');
 
   return (
-    <section className="mx-auto max-w-3xl px-6 py-24">
+    <section id="faq" className="mx-auto max-w-3xl scroll-mt-20 px-6 py-24">
       <SectionHeading eyebrow={t('eyebrow')} title={t('title')} />
       <Accordion hideSeparator className="mt-12 border-y">
         {FAQ_ITEMS.map((key) => (
           <Accordion.Item
             key={key}
             id={key}
-            className="border-b last:border-b-0"
+            data-scroll-reveal=""
+            className="landing-scroll-reveal border-b last:border-b-0"
           >
             <Accordion.Heading>
               <Accordion.Trigger className="flex w-full items-center justify-between gap-4 py-5 text-left text-sm font-medium">

--- a/client/src/app/home/hero.tsx
+++ b/client/src/app/home/hero.tsx
@@ -17,7 +17,7 @@ export default function Hero() {
         className={buttonVariants({
           variant: 'outline',
           size: 'sm',
-          className: 'gap-2'
+          className: 'landing-reveal gap-2'
         })}
       >
         <Chip color="success" size="sm" variant="soft">
@@ -27,17 +27,17 @@ export default function Hero() {
         <ChevronRightIcon className="text-muted h-3 w-3 transition group-hover:translate-x-0.5" />
       </Link>
 
-      <h1 className="mx-auto mt-7 max-w-5xl text-5xl font-medium leading-[0.98] tracking-tight sm:text-6xl md:text-7xl lg:text-8xl">
+      <h1 className="landing-reveal landing-delay-1 mx-auto mt-7 max-w-5xl text-5xl font-medium leading-[0.98] tracking-tight sm:text-6xl md:text-7xl lg:text-8xl">
         {t('title')}
         <br />
         <span className="text-muted">{t('title_accent')}</span>
       </h1>
 
-      <p className="text-muted mx-auto mt-6 max-w-2xl text-base leading-relaxed md:text-lg">
+      <p className="text-muted landing-reveal landing-delay-2 mx-auto mt-6 max-w-2xl text-base leading-relaxed md:text-lg">
         {t('subtitle')}
       </p>
 
-      <div className="mt-9 flex flex-wrap items-center justify-center gap-3">
+      <div className="landing-reveal landing-delay-3 mt-9 flex flex-wrap items-center justify-center gap-3">
         <Link
           href={CREATE_INVOICE_PAGE}
           className={buttonVariants({
@@ -59,9 +59,13 @@ export default function Hero() {
         </Link>
       </div>
 
-      <p className="text-muted mt-5 text-xs">{t('note')}</p>
+      <p className="text-muted landing-reveal landing-delay-4 mt-5 text-xs">
+        {t('note')}
+      </p>
 
-      <ProductPreview />
+      <div className="landing-reveal landing-delay-5">
+        <ProductPreview />
+      </div>
     </section>
   );
 }

--- a/client/src/app/home/home-page-content.tsx
+++ b/client/src/app/home/home-page-content.tsx
@@ -3,10 +3,12 @@ import FAQ from './faq';
 import Hero from './hero';
 import Pricing from './pricing/pricing';
 import ProductSection from './product/product-section';
+import ScrollRevealProvider from './scroll-reveal-provider';
 
 export default function HomePageContent() {
   return (
     <main className="relative isolate overflow-hidden">
+      <ScrollRevealProvider />
       <Hero />
       <ProductSection />
       <Pricing />

--- a/client/src/app/home/pricing/price-card.tsx
+++ b/client/src/app/home/pricing/price-card.tsx
@@ -14,11 +14,15 @@ import { PRICING_PLANS } from './constants';
 export default function PriceCard({
   plan,
   currencySymbol,
-  highlighted
+  highlighted,
+  className,
+  reveal
 }: {
   plan: (typeof PRICING_PLANS)[number];
   currencySymbol: string;
   highlighted?: boolean;
+  className?: string;
+  reveal?: boolean;
 }) {
   const t = useTranslations(`home.pricing.${plan}`);
   const monthlyPrice = formatSubscriptionPrice(SUBSCRIPTION_AMOUNT);
@@ -30,11 +34,13 @@ export default function PriceCard({
 
   return (
     <Card
+      data-scroll-reveal={reveal ? '' : undefined}
       className={cn(
-        'relative overflow-hidden border p-8',
+        'landing-hover-lift relative overflow-hidden border p-8',
         highlighted
           ? 'border-accent/40 shadow-accent/10 backdrop-blur-xs bg-transparent shadow-lg'
-          : 'backdrop-blur-xs bg-transparent'
+          : 'backdrop-blur-xs bg-transparent',
+        className
       )}
     >
       {highlighted && (

--- a/client/src/app/home/pricing/pricing.tsx
+++ b/client/src/app/home/pricing/pricing.tsx
@@ -41,7 +41,7 @@ export default function Pricing() {
     <section
       ref={sectionRef}
       id="pricing"
-      className="mx-auto max-w-5xl px-6 py-24"
+      className="mx-auto max-w-5xl scroll-mt-20 px-6 py-24"
     >
       <SectionHeading
         eyebrow={t('eyebrow')}
@@ -56,6 +56,8 @@ export default function Pricing() {
             plan={plan}
             currencySymbol={currencySymbol}
             highlighted={plan === 'premium'}
+            reveal
+            className="landing-scroll-reveal"
           />
         ))}
       </div>

--- a/client/src/app/home/product/product-section.tsx
+++ b/client/src/app/home/product/product-section.tsx
@@ -46,7 +46,10 @@ export default function ProductSection() {
   const t = useTranslations('home.product');
 
   return (
-    <section id="features" className="mx-auto max-w-7xl px-6 pb-16 pt-24">
+    <section
+      id="features"
+      className="mx-auto max-w-7xl scroll-mt-20 px-6 pb-16 pt-24"
+    >
       <SectionHeading
         eyebrow={t('eyebrow')}
         title={t('title')}
@@ -56,7 +59,13 @@ export default function ProductSection() {
 
       <div className="mt-14 grid grid-cols-1 gap-3 md:grid-cols-6">
         {productTiles.map(({ key, icon, className }) => (
-          <Tile key={key} className={className}>
+          <Tile
+            key={key}
+            reveal
+            className={['landing-scroll-reveal', className]
+              .filter(Boolean)
+              .join(' ')}
+          >
             <TileBody
               icon={icon}
               eyebrow={
@@ -78,7 +87,13 @@ export default function ProductSection() {
 
       <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
         {capabilityTiles.map(({ key, icon, className }) => (
-          <Tile key={key} className={className}>
+          <Tile
+            key={key}
+            reveal
+            className={['landing-scroll-reveal', className]
+              .filter(Boolean)
+              .join(' ')}
+          >
             <TileBody
               icon={icon}
               title={t(`capabilities.${key}.title`)}

--- a/client/src/app/home/scroll-reveal-provider.tsx
+++ b/client/src/app/home/scroll-reveal-provider.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const SCROLL_REVEAL_SELECTOR = '[data-scroll-reveal]';
+
+const clamp = (value: number) => Math.min(Math.max(value, 0), 1);
+
+export default function ScrollRevealProvider() {
+  useEffect(() => {
+    let elements: HTMLElement[] = [];
+
+    const refreshElements = () => {
+      elements = Array.from(
+        document.querySelectorAll<HTMLElement>(SCROLL_REVEAL_SELECTOR)
+      );
+    };
+
+    refreshElements();
+
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    );
+
+    let animationFrame = 0;
+
+    const update = () => {
+      animationFrame = 0;
+
+      if (prefersReducedMotion.matches) {
+        elements.forEach((element) => {
+          element.style.opacity = '1';
+          element.style.transform = 'none';
+        });
+        return;
+      }
+
+      const viewportHeight = window.innerHeight || 1;
+      const start = viewportHeight * 0.92;
+      const end = viewportHeight * 0.6;
+      const travel = start - end;
+
+      elements.forEach((element) => {
+        const rect = element.getBoundingClientRect();
+        const progress = clamp((start - rect.top) / travel);
+        const translateY = Math.round((1 - progress) * 18);
+
+        element.style.opacity = progress.toFixed(3);
+        element.style.transform = `translateY(${translateY}px)`;
+        element.style.transition =
+          'opacity 120ms linear, transform 120ms linear';
+      });
+    };
+
+    const requestUpdate = () => {
+      if (animationFrame) return;
+
+      animationFrame = window.requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener('scroll', requestUpdate, { passive: true });
+    window.addEventListener('resize', requestUpdate);
+    prefersReducedMotion.addEventListener('change', requestUpdate);
+    const observer = new MutationObserver(() => {
+      refreshElements();
+      requestUpdate();
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+
+    return () => {
+      if (animationFrame) window.cancelAnimationFrame(animationFrame);
+      window.removeEventListener('scroll', requestUpdate);
+      window.removeEventListener('resize', requestUpdate);
+      prefersReducedMotion.removeEventListener('change', requestUpdate);
+      observer.disconnect();
+    };
+  }, []);
+
+  return null;
+}

--- a/client/src/app/home/section-heading.tsx
+++ b/client/src/app/home/section-heading.tsx
@@ -10,10 +10,11 @@ export default function SectionHeading({
   body?: string;
 }) {
   return (
-    <div className="mx-auto max-w-2xl text-center">
-      {eyebrow && (
-        <div className="section-eyebrow text-muted">{eyebrow}</div>
-      )}
+    <div
+      className="landing-scroll-reveal mx-auto max-w-2xl text-center"
+      data-scroll-reveal=""
+    >
+      {eyebrow && <div className="section-eyebrow text-muted">{eyebrow}</div>}
       <h2 className="mt-3 text-4xl font-medium tracking-tight md:text-5xl">
         {title}
         {accent && (

--- a/client/src/app/home/tile/tile.tsx
+++ b/client/src/app/home/tile/tile.tsx
@@ -3,15 +3,18 @@ import { ReactNode } from 'react';
 
 export default function Tile({
   className,
-  children
+  children,
+  reveal
 }: {
   className?: string;
   children: ReactNode;
+  reveal?: boolean;
 }) {
   return (
     <Card
+      data-scroll-reveal={reveal ? '' : undefined}
       className={cn(
-        'landing-surface hover:border-default-300 backdrop-blur-xs group relative overflow-hidden border p-6 transition',
+        'landing-surface landing-hover-lift hover:border-default-300 backdrop-blur-xs group relative overflow-hidden border p-6 transition',
         className
       )}
     >

--- a/client/src/app/invoices/public/[token]/loading.tsx
+++ b/client/src/app/invoices/public/[token]/loading.tsx
@@ -1,0 +1,5 @@
+import { PublicInvoicePageSkeleton } from '@/components/ui/skeletons/public-page-skeletons';
+
+export default function PublicInvoiceLoading() {
+  return <PublicInvoicePageSkeleton />;
+}

--- a/client/src/app/invoices/sign/[token]/loading.tsx
+++ b/client/src/app/invoices/sign/[token]/loading.tsx
@@ -1,0 +1,5 @@
+import { PublicInvoicePageSkeleton } from '@/components/ui/skeletons/public-page-skeletons';
+
+export default function InvoiceSigningLoading() {
+  return <PublicInvoicePageSkeleton />;
+}

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -57,7 +57,7 @@ export default async function RootLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body className={inter.className}>
+      <body className={inter.className} suppressHydrationWarning>
         <Providers messages={messages}>
           <Suspense fallback={null}>
             <AnalyticsProvider

--- a/client/src/app/privacy-policy/loading.tsx
+++ b/client/src/app/privacy-policy/loading.tsx
@@ -1,0 +1,5 @@
+import { LegalPageSkeleton } from '@/components/ui/skeletons/public-page-skeletons';
+
+export default function PrivacyPolicyLoading() {
+  return <LegalPageSkeleton />;
+}

--- a/client/src/app/terms-of-service/loading.tsx
+++ b/client/src/app/terms-of-service/loading.tsx
@@ -1,0 +1,5 @@
+import { LegalPageSkeleton } from '@/components/ui/skeletons/public-page-skeletons';
+
+export default function TermsOfServiceLoading() {
+  return <LegalPageSkeleton />;
+}

--- a/client/src/components/app-logo.tsx
+++ b/client/src/components/app-logo.tsx
@@ -15,6 +15,7 @@ const AppLogo = ({ height = 40, width = 40 }: Props) => {
       height={height}
       src="/logo.png"
       alt={t('app_logo_alt')}
+      style={{ width, height: 'auto' }}
       loading="eager"
       priority
     />

--- a/client/src/components/invoice/invoice-services-table.tsx
+++ b/client/src/components/invoice/invoice-services-table.tsx
@@ -13,8 +13,7 @@ import {
   TableHeader,
   TableRow,
   TableScrollContainer,
-  TextField,
-  Tooltip
+  TextField
 } from '@heroui/react';
 import {
   type ComponentProps,
@@ -312,20 +311,15 @@ const InvoiceServicesTable = ({
             aria-label={t('a11y.actions_label')}
             className="relative flex items-center gap-2"
           >
-            <Tooltip delay={0}>
-              <Tooltip.Trigger>
-                <Button
-                  aria-label={t('delete_service')}
-                  onPress={() => handleRemoveService(index)}
-                  variant="tertiary"
-                  data-invoice-service-focusable
-                  className="text-danger min-w-min cursor-pointer p-3 text-lg active:opacity-50"
-                >
-                  <TrashIcon className="h-5 w-5" />
-                </Button>
-              </Tooltip.Trigger>
-              <Tooltip.Content>{t('delete_service')}</Tooltip.Content>
-            </Tooltip>
+            <Button
+              aria-label={t('delete_service')}
+              onPress={() => handleRemoveService(index)}
+              variant="tertiary"
+              data-invoice-service-focusable
+              className="text-danger min-w-min cursor-pointer p-3 text-lg active:opacity-50"
+            >
+              <TrashIcon className="h-5 w-5" />
+            </Button>
           </div>
         );
       default:
@@ -355,7 +349,7 @@ const InvoiceServicesTable = ({
             </TableHeader>
             <TableBody>
               {fields.map((field, index) => (
-                <TableRow key={field.id} id={field.id}>
+                <TableRow key={field.id} id={`service-${index}`}>
                   {INVOICE_SERVICE_COLUMNS.map((column) => (
                     <TableCell key={column.uid}>
                       {renderCell(column.uid, index)}

--- a/client/src/components/invoice/invoice-table-cell.tsx
+++ b/client/src/components/invoice/invoice-table-cell.tsx
@@ -219,7 +219,7 @@ const InvoiceTableCell = ({
               <Dropdown>
                 <DropdownTrigger
                   isDisabled={isPending}
-                  className="cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 [&[aria-expanded=true]_svg]:rotate-180"
+                  className="h-auto min-w-0 cursor-pointer bg-transparent p-0 disabled:cursor-not-allowed disabled:opacity-50 [&[aria-expanded=true]_svg]:rotate-180"
                 >
                   <Chip
                     className="capitalize"

--- a/client/src/components/layout/guest-header.tsx
+++ b/client/src/components/layout/guest-header.tsx
@@ -27,27 +27,38 @@ import LanguageSwitcher from './language-switcher';
 import ThemeSwitcher from './theme-switcher';
 
 const navbarItems = [
-  { name: 'Features', href: '#features' },
-  { name: 'Pricing', href: '#pricing' }
+  { key: 'features', href: '#features' },
+  { key: 'pricing', href: '#pricing' },
+  { key: 'faq', href: '#faq' }
 ];
 
 export default function GuestHeader() {
   const t = useTranslations('header.guest');
   const pathname = usePathname();
+  const getNavbarHref = (href: string) =>
+    pathname !== HOME_PAGE ? HOME_PAGE + href : href;
 
   const renderMobileNavbarContent = () => {
     return (
       <Dropdown>
         <DropdownTrigger
+          aria-label={t('mobile_menu')}
           className={buttonVariants({
             variant: 'secondary',
-            className: 'flex size-10 items-center justify-center p-0 md:hidden'
+            isIconOnly: true,
+            className: 'md:hidden'
           })}
         >
           <Bars3Icon className="h-5 w-5" />
         </DropdownTrigger>
         <DropdownPopover>
           <DropdownMenu>
+            {navbarItems.map((item) => (
+              <DropdownItem key={item.key} href={getNavbarHref(item.href)}>
+                {t(item.key)}
+              </DropdownItem>
+            ))}
+            <Separator />
             <DropdownItem
               key="create-invoice"
               className="text-secondary"
@@ -84,20 +95,18 @@ export default function GuestHeader() {
         </Link>
 
         <div className="hidden gap-4 md:flex">
-          {navbarItems.map((item, index) => {
+          {navbarItems.map((item) => {
             const isActive = pathname?.includes(item.href);
 
             return (
-              <div key={index} aria-current={isActive ? 'page' : undefined}>
+              <div key={item.key} aria-current={isActive ? 'page' : undefined}>
                 <Link
-                  href={
-                    pathname !== HOME_PAGE ? HOME_PAGE + item.href : item.href
-                  }
+                  href={getNavbarHref(item.href)}
                   className={cn('text-foreground', {
                     'text-primary': isActive
                   })}
                 >
-                  {t(item.name.toLowerCase())}
+                  {t(item.key)}
                 </Link>
               </div>
             );

--- a/client/src/components/ui/skeletons/public-page-skeletons.tsx
+++ b/client/src/components/ui/skeletons/public-page-skeletons.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { Card, Skeleton } from '@heroui/react';
+
+export function AuthPageSkeleton() {
+  return (
+    <section className="flex flex-1 items-center justify-center">
+      <Card className="w-full max-w-lg border p-8">
+        <Skeleton className="mx-auto h-10 w-10 rounded-xl" />
+        <Skeleton className="mx-auto mt-5 h-7 w-44 rounded-xl" />
+        <Skeleton className="mx-auto mt-3 h-4 w-64 rounded-xl" />
+        <Skeleton className="mt-8 h-11 w-full rounded-xl" />
+        <div className="flex items-center gap-3 py-5">
+          <Skeleton className="h-px flex-1 rounded-xl" />
+          <Skeleton className="h-3 w-24 rounded-xl" />
+          <Skeleton className="h-px flex-1 rounded-xl" />
+        </div>
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-14 w-full rounded-xl" />
+          <Skeleton className="h-14 w-full rounded-xl" />
+          <Skeleton className="h-11 w-full rounded-xl" />
+        </div>
+      </Card>
+    </section>
+  );
+}
+
+export function CreateInvoicePageSkeleton() {
+  return (
+    <section className="mx-auto w-full max-w-7xl px-6 py-8 sm:py-10 md:py-12 lg:py-14">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(280px,360px)] lg:items-end">
+        <div>
+          <Skeleton className="h-7 w-48 rounded-xl" />
+          <Skeleton className="mt-4 h-10 w-full max-w-2xl rounded-xl" />
+          <Skeleton className="mt-3 h-5 w-full max-w-xl rounded-xl" />
+        </div>
+        <Card className="border p-4">
+          <Skeleton className="h-5 w-40 rounded-xl" />
+          <Skeleton className="mt-3 h-4 w-full rounded-xl" />
+          <Skeleton className="mt-4 h-10 w-full rounded-xl" />
+        </Card>
+      </div>
+      <div className="mt-6 grid gap-3 md:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Skeleton key={index} className="h-16 w-full rounded-xl" />
+        ))}
+      </div>
+      <Card className="mt-8 border p-4 sm:p-8">
+        <Skeleton className="h-6 w-36 rounded-xl" />
+        <div className="mt-4 grid gap-4 md:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-14 rounded-xl" />
+          ))}
+        </div>
+        <div className="mt-8 grid gap-4 md:grid-cols-2">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <Skeleton key={index} className="h-[360px] rounded-3xl" />
+          ))}
+        </div>
+        <Skeleton className="mt-8 h-[220px] rounded-3xl" />
+        <div className="mt-8 flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <Skeleton className="h-10 w-full rounded-xl sm:w-28" />
+          <Skeleton className="h-10 w-full rounded-xl sm:w-44" />
+        </div>
+      </Card>
+    </section>
+  );
+}
+
+export function PublicInvoicePageSkeleton() {
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-8">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <Card className="border p-4 sm:p-6">
+          <Skeleton className="h-[720px] w-full rounded-xl" />
+        </Card>
+        <div className="flex flex-col gap-4">
+          <Card className="border p-5">
+            <Skeleton className="h-6 w-44 rounded-xl" />
+            <Skeleton className="mt-3 h-4 w-full rounded-xl" />
+            <Skeleton className="mt-6 h-10 w-full rounded-xl" />
+          </Card>
+          <Card className="border p-5">
+            <Skeleton className="h-5 w-36 rounded-xl" />
+            <Skeleton className="mt-4 h-24 w-full rounded-xl" />
+          </Card>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export function LegalPageSkeleton() {
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-8">
+      <Skeleton className="h-9 w-56 rounded-xl" />
+      <Skeleton className="mt-3 h-4 w-40 rounded-xl" />
+      <div className="mt-8 space-y-6">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <section key={index}>
+            <Skeleton className="h-6 w-64 rounded-xl" />
+            <Skeleton className="mt-3 h-4 w-full rounded-xl" />
+            <Skeleton className="mt-2 h-4 w-11/12 rounded-xl" />
+            <Skeleton className="mt-2 h-4 w-4/5 rounded-xl" />
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
### Overview
Adds the REK-77 home page motion and public-page loading states.

- Adds hero load motion, scroll-linked section reveal behavior, hover polish, and smoother anchor scrolling for the home page.
- Adds skeleton loading states for auth, free invoice, public invoice, signing, privacy policy, and terms routes.
- Shortens the Lithuanian hero copy and adds FAQ navigation labels.

### Additional changes
- Fixes create-invoice table hydration noise by using deterministic service row ids.
- Adjusts HeroUI dropdown trigger usage and removes a problematic services-table tooltip wrapper.
- Adds body hydration-warning suppression for extension-injected attributes and stabilizes the app logo image aspect ratio.

Checks were not run locally per repo handoff instructions.