### PR TITLE
Polish card surfaces and icon wells

### DIFF
--- a/client/src/app/(user)/payment-success/payment-success-content.tsx
+++ b/client/src/app/(user)/payment-success/payment-success-content.tsx
@@ -24,6 +24,7 @@ import {
   DASHBOARD_PAGE,
   RENEW_SUBSCRIPTION_PAGE
 } from '@/lib/constants/pages';
+import IconContainer from '@/components/ui/icon-container';
 import { formatLocalizedDate } from '@/lib/utils/date';
 
 type Props = {
@@ -247,9 +248,9 @@ export default function PaymentSuccessContent({ isTrial, billing }: Props) {
                 href={href}
                 className="glass-card glass-card-interactive hover:border-secondary/40 group relative overflow-hidden rounded-2xl p-5"
               >
-                <div className="bg-secondary/10 text-secondary grid h-9 w-9 place-items-center rounded-lg">
+                <IconContainer variant="secondary" className="rounded-lg">
                   <Icon className="h-4 w-4" strokeWidth={2.2} />
-                </div>
+                </IconContainer>
                 <div className="text-foreground mt-4 text-sm font-medium">
                   {t(titleKey)}
                 </div>

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -32,11 +32,6 @@
   );
 }
 
-@utility landing-surface {
-  border-color: color-mix(in oklab, currentColor 14%, transparent);
-  background: transparent;
-}
-
 @layer components {
   html {
     scroll-behavior: smooth;

--- a/client/src/app/home/clients-page-preview.tsx
+++ b/client/src/app/home/clients-page-preview.tsx
@@ -17,7 +17,8 @@ export default function ClientsPagePreview() {
         {clients.map((key) => (
           <Card
             key={key}
-            className="hover:border-secondary/50 group relative overflow-hidden border transition hover:shadow-md"
+            variant="secondary"
+            className="relative overflow-hidden border"
           >
             <Card.Content className="flex h-full flex-col gap-3 px-3 py-2">
               <div className="pr-20">

--- a/client/src/app/home/contracts-soon-preview.tsx
+++ b/client/src/app/home/contracts-soon-preview.tsx
@@ -1,12 +1,15 @@
+import { Card } from '@heroui/react';
 import { useTranslations } from 'next-intl';
 
 export default function ContractsSoonPreview() {
   const t = useTranslations('home.product.contract_preview');
 
   return (
-    <div className="bg-default-50/70 mt-6 rounded-3xl border border-dashed p-5">
-      <span className="text-muted font-mono text-xs">CTR-0014</span>
-      <p className="text-muted mt-3 text-sm">{t('description')}</p>
-    </div>
+    <Card variant="tertiary" className="mt-6 border border-dashed">
+      <Card.Content>
+        <span className="text-muted font-mono text-xs">CTR-0014</span>
+        <p className="text-muted mt-3 text-sm">{t('description')}</p>
+      </Card.Content>
+    </Card>
   );
 }

--- a/client/src/app/home/cta.tsx
+++ b/client/src/app/home/cta.tsx
@@ -11,7 +11,7 @@ export default function CTA() {
     <section id="start" className="mx-auto max-w-5xl scroll-mt-20 px-6 py-24">
       <Card
         data-scroll-reveal=""
-        className="landing-scroll-reveal landing-hover-lift backdrop-blur-xs relative overflow-hidden border bg-transparent p-8 text-center shadow-none sm:p-16"
+        className="landing-scroll-reveal landing-hover-lift relative overflow-hidden border p-8 text-center sm:p-16"
       >
         <div className="landing-glow-mint text-accent pointer-events-none absolute left-1/2 top-0 h-64 w-full -translate-x-1/2 opacity-25 blur-3xl" />
         <div className="via-accent/50 pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent to-transparent" />

--- a/client/src/app/home/dashboard-metric-grid.tsx
+++ b/client/src/app/home/dashboard-metric-grid.tsx
@@ -4,8 +4,10 @@ import {
   DocumentCurrencyDollarIcon,
   UsersIcon
 } from '@heroicons/react/24/outline';
-import { Card, cn } from '@heroui/react';
+import { Card } from '@heroui/react';
 import { useTranslations } from 'next-intl';
+
+import IconContainer from '@/components/ui/icon-container';
 
 export default function DashboardMetricGrid() {
   const t = useTranslations('home.preview.dashboard.cards');
@@ -13,39 +15,34 @@ export default function DashboardMetricGrid() {
     {
       key: 'paid',
       icon: BanknotesIcon,
-      iconClassName: 'bg-success/15 text-success'
+      iconVariant: 'success'
     },
     {
       key: 'pending',
       icon: ClockIcon,
-      iconClassName: 'bg-warning/15 text-warning'
+      iconVariant: 'warning'
     },
     {
       key: 'invoices',
       icon: DocumentCurrencyDollarIcon,
-      iconClassName: 'bg-accent/15 text-accent'
+      iconVariant: 'accent'
     },
     {
       key: 'clients',
       icon: UsersIcon,
-      iconClassName: 'bg-accent/15 text-accent'
+      iconVariant: 'accent'
     }
   ] as const;
 
   return (
     <section className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-      {cards.map(({ key, icon: Icon, iconClassName }) => (
-        <Card key={key} className="border bg-transparent shadow-none">
+      {cards.map(({ key, icon: Icon, iconVariant }) => (
+        <Card key={key} variant="secondary" className="border">
           <Card.Content className="flex h-full flex-col justify-between p-0 sm:p-3">
             <div className="text-muted flex items-center gap-2 text-xs font-medium">
-              <span
-                className={cn(
-                  'inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg',
-                  iconClassName
-                )}
-              >
+              <IconContainer size="sm" variant={iconVariant}>
                 <Icon className="h-3.5 w-3.5" />
-              </span>
+              </IconContainer>
               {t(`${key}.label`)}
             </div>
             <p className="mt-4 text-xl font-semibold tabular-nums">

--- a/client/src/app/home/invoices-page-preview.tsx
+++ b/client/src/app/home/invoices-page-preview.tsx
@@ -1,4 +1,4 @@
-import { Chip } from '@heroui/react';
+import { Card, Chip } from '@heroui/react';
 import { useTranslations } from 'next-intl';
 
 import PreviewToolbar from './preview-toolbar';
@@ -20,7 +20,7 @@ export function InvoicesPagePreview() {
         total={t('total')}
         rowsPerPage={t('rows_per_page')}
       />
-      <div className="bg-background overflow-hidden rounded-3xl border">
+      <Card variant="secondary" className="overflow-hidden border">
         <div className="text-muted grid grid-cols-[1.2fr_1.3fr_1fr_1fr_1fr] gap-3 border-b px-4 py-3 text-[10px] font-medium uppercase tracking-wide">
           <span>{t('columns.id')}</span>
           <span>{t('columns.receiver')}</span>
@@ -33,9 +33,7 @@ export function InvoicesPagePreview() {
             key={key}
             className="grid grid-cols-[1.2fr_1.3fr_1fr_1fr_1fr] items-center gap-3 border-b px-4 py-3 text-xs last:border-b-0"
           >
-            <span className="text-muted font-mono">
-              {t(`rows.${key}.id`)}
-            </span>
+            <span className="text-muted font-mono">{t(`rows.${key}.id`)}</span>
             <span className="truncate font-medium">
               {t(`rows.${key}.client`)}
             </span>
@@ -48,7 +46,7 @@ export function InvoicesPagePreview() {
             </Chip>
           </div>
         ))}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/client/src/app/home/latest-invoices-panel-preview.tsx
+++ b/client/src/app/home/latest-invoices-panel-preview.tsx
@@ -1,4 +1,4 @@
-import { Chip, buttonVariants } from '@heroui/react';
+import { Card, Chip, buttonVariants } from '@heroui/react';
 import { ArrowUpRightIcon } from '@heroicons/react/24/outline';
 import { useTranslations } from 'next-intl';
 
@@ -11,11 +11,13 @@ export default function LatestInvoicesPanelPreview() {
   ] as const;
 
   return (
-    <section className="w-full min-w-0 rounded-3xl border bg-transparent p-5 shadow-none">
-      <div className="flex items-start justify-between gap-4">
+    <Card variant="secondary" className="w-full min-w-0 border">
+      <Card.Header className="items-start justify-between gap-4">
         <div>
-          <h3 className="text-base font-semibold">{t('title')}</h3>
-          <p className="text-muted mt-1 text-sm">{t('subtitle')}</p>
+          <Card.Title className="text-base font-semibold">
+            {t('title')}
+          </Card.Title>
+          <Card.Description className="mt-1">{t('subtitle')}</Card.Description>
         </div>
         <span
           className={buttonVariants({
@@ -27,42 +29,44 @@ export default function LatestInvoicesPanelPreview() {
           {t('view_all')}
           <ArrowUpRightIcon className="h-3.5 w-3.5" />
         </span>
-      </div>
+      </Card.Header>
 
-      <ul className="divide-default-200 mt-4 divide-y">
-        {rows.map(({ key, color }) => (
-          <li
-            key={key}
-            className="flex items-center gap-3 py-3.5 first:pt-2 last:pb-2"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <span className="truncate text-sm font-medium">
-                  {t(`rows.${key}.client`)}
-                </span>
-                <Chip
-                  size="sm"
-                  color={color}
-                  variant="soft"
-                  className="h-5 shrink-0 text-[11px] font-medium"
-                >
-                  {t(`rows.${key}.status`)}
-                </Chip>
+      <Card.Content>
+        <ul className="divide-default-200 divide-y">
+          {rows.map(({ key, color }) => (
+            <li
+              key={key}
+              className="flex items-center gap-3 py-3.5 first:pt-0 last:pb-0"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-medium">
+                    {t(`rows.${key}.client`)}
+                  </span>
+                  <Chip
+                    size="sm"
+                    color={color}
+                    variant="soft"
+                    className="h-5 shrink-0 text-[11px] font-medium"
+                  >
+                    {t(`rows.${key}.status`)}
+                  </Chip>
+                </div>
+                <div className="text-muted mt-0.5 flex min-w-0 items-center gap-1.5 text-[11px]">
+                  <span className="shrink-0 tabular-nums">
+                    {t(`rows.${key}.id`)}
+                  </span>
+                  <span aria-hidden>·</span>
+                  <span className="shrink-0">{t(`rows.${key}.date`)}</span>
+                </div>
               </div>
-              <div className="text-muted mt-0.5 flex min-w-0 items-center gap-1.5 text-[11px]">
-                <span className="shrink-0 tabular-nums">
-                  {t(`rows.${key}.id`)}
-                </span>
-                <span aria-hidden>·</span>
-                <span className="shrink-0">{t(`rows.${key}.date`)}</span>
+              <div className="shrink-0 text-right text-sm font-semibold tabular-nums">
+                {t(`rows.${key}.amount`)}
               </div>
-            </div>
-            <div className="shrink-0 text-right text-sm font-semibold tabular-nums">
-              {t(`rows.${key}.amount`)}
-            </div>
-          </li>
-        ))}
-      </ul>
-    </section>
+            </li>
+          ))}
+        </ul>
+      </Card.Content>
+    </Card>
   );
 }

--- a/client/src/app/home/pricing/price-card.tsx
+++ b/client/src/app/home/pricing/price-card.tsx
@@ -37,9 +37,6 @@ export default function PriceCard({
       data-scroll-reveal={reveal ? '' : undefined}
       className={cn(
         'landing-hover-lift relative overflow-hidden border p-8',
-        highlighted
-          ? 'border-accent/40 shadow-accent/10 backdrop-blur-xs bg-transparent shadow-lg'
-          : 'backdrop-blur-xs bg-transparent',
         className
       )}
     >

--- a/client/src/app/home/product/product-preview.tsx
+++ b/client/src/app/home/product/product-preview.tsx
@@ -21,21 +21,21 @@ export default function ProductPreview() {
   return (
     <div className="relative mx-auto mt-20 max-w-6xl">
       <div className="landing-glow-mint text-accent absolute -inset-x-16 -inset-y-10 blur-2xl" />
-      <Card className="bg-background/80 shadow-default-200/40 relative overflow-hidden rounded-2xl border p-0 shadow-2xl backdrop-blur dark:bg-zinc-900/85 dark:shadow-black/60">
-        <Card.Header className="bg-default-50/80 flex-row items-center gap-3 border-b px-4 py-2.5 dark:bg-zinc-900/90">
+      <Card className="relative overflow-hidden border p-0">
+        <Card.Header className="flex-row items-center gap-3 border-b px-4 py-2.5">
           <div className="flex gap-1.5">
             <span className="bg-danger h-2.5 w-2.5 rounded-full" />
             <span className="bg-warning h-2.5 w-2.5 rounded-full" />
             <span className="bg-success h-2.5 w-2.5 rounded-full" />
           </div>
-          <div className="bg-default mx-auto flex max-w-md flex-1 items-center justify-center rounded-md px-3 py-1 text-center text-[11px] dark:bg-zinc-800/80 dark:text-zinc-400">
+          <div className="bg-default mx-auto flex max-w-md flex-1 items-center justify-center rounded-md px-3 py-1 text-center text-[11px]">
             invoicetrackr.app / dashboard
           </div>
         </Card.Header>
 
         <div className="-mt-3 grid grid-cols-12">
-          <aside className="bg-default/60 hidden border-r p-4 text-start md:col-span-3 md:block dark:bg-zinc-950/40">
-            <div className="section-eyebrow text-muted mb-4 dark:text-zinc-500">
+          <aside className="hidden border-r p-4 text-start md:col-span-3 md:block">
+            <div className="section-eyebrow text-muted mb-4">
               {t('sidebar.eyebrow')}
             </div>
             {navItems.map(({ icon: Icon, key, active, disabled }) => (
@@ -44,8 +44,8 @@ export default function ProductPreview() {
                 className={cn(
                   'rounded-medium mb-1 flex items-center justify-between rounded-lg px-2.5 py-1.5 text-xs',
                   active
-                    ? 'bg-accent/15 text-foreground ring-accent/20 ring-1 dark:bg-white/[0.08] dark:text-zinc-100 dark:ring-white/[0.06]'
-                    : 'text-muted dark:text-zinc-500',
+                    ? 'bg-accent/15 text-foreground ring-accent/20 ring-1'
+                    : 'text-muted',
                   disabled && 'opacity-60'
                 )}
               >
@@ -62,7 +62,7 @@ export default function ProductPreview() {
             ))}
           </aside>
 
-          <div className="text-foreground bg-default-50/20 col-span-12 p-4 text-start md:col-span-9 md:p-6 dark:bg-zinc-900/25">
+          <div className="text-foreground col-span-12 p-4 text-start md:col-span-9 md:p-6">
             <DashboardPagePreview />
           </div>
         </div>

--- a/client/src/app/home/revenue-panel-preview.tsx
+++ b/client/src/app/home/revenue-panel-preview.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@heroui/react';
 import { useTranslations } from 'next-intl';
 
 export default function RevenuePanelPreview() {
@@ -19,22 +20,28 @@ export default function RevenuePanelPreview() {
   ];
 
   return (
-    <section className="flex min-h-72 flex-col rounded-3xl border bg-transparent p-5 shadow-none">
-      <h3 className="text-base font-semibold">{t('title')}</h3>
-      <div className="mt-6 grid min-h-48 grid-cols-12 items-end gap-1.5 border-b border-l px-3 pb-3 sm:gap-2">
-        {bars.map((height, index) => (
-          <div
-            key={index}
-            className="bg-accent rounded-t-md"
-            style={{ height: `${height}%` }}
-          />
-        ))}
-      </div>
-      <div className="text-muted mt-3 flex justify-between text-[10px]">
-        {months.map((month) => (
-          <span key={month}>{month}</span>
-        ))}
-      </div>
-    </section>
+    <Card variant="secondary" className="min-h-72 border">
+      <Card.Header>
+        <Card.Title className="text-base font-semibold">
+          {t('title')}
+        </Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <div className="grid min-h-48 grid-cols-12 items-end gap-1.5 border-b border-l px-3 pb-3 sm:gap-2">
+          {bars.map((height, index) => (
+            <div
+              key={index}
+              className="bg-accent rounded-t-md"
+              style={{ height: `${height}%` }}
+            />
+          ))}
+        </div>
+        <div className="text-muted mt-3 flex justify-between text-[10px]">
+          {months.map((month) => (
+            <span key={month}>{month}</span>
+          ))}
+        </div>
+      </Card.Content>
+    </Card>
   );
 }

--- a/client/src/app/home/tile/tile-body.tsx
+++ b/client/src/app/home/tile/tile-body.tsx
@@ -1,4 +1,6 @@
 import { Chip } from '@heroui/react';
+import IconContainer from '@/components/ui/icon-container';
+
 import { IconComponent } from './types';
 
 export default function TileBody({
@@ -19,9 +21,9 @@ export default function TileBody({
   return (
     <div>
       {Icon && (
-        <div className="bg-default-50 text-muted mb-4 inline-grid h-9 w-9 place-items-center rounded-lg border">
+        <IconContainer className="mb-4 rounded-lg">
           <Icon className="h-4 w-4" />
-        </div>
+        </IconContainer>
       )}
       {eyebrow && (
         <div className="section-eyebrow text-muted mb-2">{eyebrow}</div>

--- a/client/src/app/home/tile/tile.tsx
+++ b/client/src/app/home/tile/tile.tsx
@@ -14,7 +14,7 @@ export default function Tile({
     <Card
       data-scroll-reveal={reveal ? '' : undefined}
       className={cn(
-        'landing-surface landing-hover-lift hover:border-default-300 backdrop-blur-xs group relative overflow-hidden border p-6 transition',
+        'landing-hover-lift group relative overflow-hidden border p-6 transition',
         className
       )}
     >

--- a/client/src/components/auth/verify-email-result-card.tsx
+++ b/client/src/components/auth/verify-email-result-card.tsx
@@ -11,6 +11,7 @@ import { ArrowRightIcon } from '@heroicons/react/20/solid';
 import { useTranslations } from 'next-intl';
 
 import { ACCOUNT_SETTINGS_PAGE, DASHBOARD_PAGE } from '@/lib/constants/pages';
+import IconContainer from '@/components/ui/icon-container';
 import { verifyEmailTokenAction } from '@/lib/actions/user';
 
 type Props = {
@@ -39,11 +40,16 @@ export default function VerifyEmailResultCard({
   const isSuccess =
     result.status === 'verified' || result.status === 'already_verified';
   const isError = result.status === 'error';
-  const indicatorClass = isSuccess
-    ? 'bg-success/10 ring-success/30'
+  const indicatorVariant = isSuccess
+    ? 'success'
     : isError
-      ? 'bg-danger-500/10 ring-danger-400/30'
-      : 'bg-warning/10 ring-warning/30';
+      ? 'danger'
+      : 'warning';
+  const indicatorRingClass = isSuccess
+    ? 'ring-success/30'
+    : isError
+      ? 'ring-danger-400/30'
+      : 'ring-warning/30';
 
   const content = useMemo(() => {
     if (result.status === 'pending') {
@@ -116,11 +122,16 @@ export default function VerifyEmailResultCard({
   }, [result.status, token]);
 
   return (
-    <Card className="relative mx-auto w-full max-w-lg overflow-hidden rounded-2xl border">
+    <Card
+      variant="secondary"
+      className="relative mx-auto w-full max-w-lg overflow-hidden rounded-2xl border"
+    >
       <Card.Content className="px-8 pb-7 pt-8">
         <div className="flex items-center gap-4">
-          <div
-            className={`relative grid h-11 w-11 shrink-0 place-items-center rounded-xl ring-1 ${indicatorClass}`}
+          <IconContainer
+            size="lg"
+            variant={indicatorVariant}
+            className={cn('relative border-0 ring-1', indicatorRingClass)}
           >
             {isSuccess ? (
               <CheckCircleIcon
@@ -132,7 +143,7 @@ export default function VerifyEmailResultCard({
             ) : (
               <ShieldCheckIcon className="text-warning h-5 w-5" />
             )}
-          </div>
+          </IconContainer>
 
           <div className="min-w-0">
             <h1 className="mt-1 text-[19px] font-semibold tracking-tight">

--- a/client/src/components/dashboard/__tests__/dashboard-card.test.tsx
+++ b/client/src/components/dashboard/__tests__/dashboard-card.test.tsx
@@ -14,7 +14,7 @@ describe('<DashboardCard />', () => {
       title: 'Test Title',
       text: 'Test Text Content',
       icon: <>icon</>,
-      iconClassName: ''
+      iconVariant: 'accent'
     };
   });
 

--- a/client/src/components/dashboard/dashboard-card.tsx
+++ b/client/src/components/dashboard/dashboard-card.tsx
@@ -1,27 +1,27 @@
-import { Card, CardContent } from '@heroui/react';
+import { Card } from '@heroui/react';
 import { ReactNode } from 'react';
+
+import IconContainer from '@/components/ui/icon-container';
 
 type Props = {
   icon: ReactNode;
   title: ReactNode;
   text: string;
-  iconClassName: string;
+  iconVariant: 'success' | 'warning' | 'accent';
 };
 
-const DashboardCard = ({ icon, title, text, iconClassName }: Props) => {
+const DashboardCard = ({ icon, title, text, iconVariant }: Props) => {
   return (
-    <Card className="border bg-transparent backdrop-blur-3xl">
-      <CardContent className="flex h-full flex-col justify-between">
+    <Card className="border">
+      <Card.Content className="flex h-full flex-col justify-between">
         <div className="text-muted flex items-center gap-2 text-sm font-medium">
-          <span
-            className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${iconClassName}`}
-          >
+          <IconContainer size="sm" variant={iconVariant}>
             {icon}
-          </span>
+          </IconContainer>
           {title}
         </div>
         <p className="mt-5 text-2xl font-semibold tabular-nums">{text}</p>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 };

--- a/client/src/components/dashboard/dashboard-cards.tsx
+++ b/client/src/components/dashboard/dashboard-cards.tsx
@@ -48,13 +48,13 @@ const DashboardCards = async ({ userId, currency }: Props) => {
     <section className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
       <DashboardCard
         icon={<BanknotesIcon className="h-4 w-4" />}
-        iconClassName="bg-success/15 text-success"
+        iconVariant="success"
         title={t('paid')}
         text={`${currencySymbol}${totalInvoiceRevenue?.paid.toFixed(2) || '0'}`}
       />
       <DashboardCard
         icon={<ClockIcon className="h-4 w-4" />}
-        iconClassName="bg-warning/15 text-warning"
+        iconVariant="warning"
         title={t('pending')}
         text={`${currencySymbol}${
           totalInvoiceRevenue?.pending.toFixed(2) || '0'
@@ -62,13 +62,13 @@ const DashboardCards = async ({ userId, currency }: Props) => {
       />
       <DashboardCard
         icon={<DocumentCurrencyDollarIcon className="h-4 w-4" />}
-        iconClassName="bg-accent/15 text-accent"
+        iconVariant="accent"
         title={t('total_invoices')}
         text={`${invoices?.length || '0'}`}
       />
       <DashboardCard
         icon={<UsersIcon className="h-4 w-4" />}
-        iconClassName="bg-accent/15 text-accent"
+        iconVariant="accent"
         title={t('total_clients')}
         text={`${totalClients || '0'}`}
       />

--- a/client/src/components/dashboard/latest-invoices.tsx
+++ b/client/src/components/dashboard/latest-invoices.tsx
@@ -1,4 +1,4 @@
-import { Chip, buttonVariants } from '@heroui/react';
+import { Card, Chip, buttonVariants } from '@heroui/react';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { ArrowUpRightIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
@@ -36,90 +36,98 @@ const LatestInvoices = async ({ userId, currency }: Props) => {
   });
 
   return (
-    <section className="border-default-200 w-full min-w-72 rounded-3xl border p-5 shadow-sm backdrop-blur-3xl sm:p-6 xl:max-w-lg">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 className="text-base font-semibold">{t('title')}</h2>
-          <p className="text-muted mt-1 text-sm">{t('subtitle')}</p>
-        </div>
-        <Link
-          href={INVOICES_PAGE}
-          className={buttonVariants({ size: 'sm', variant: 'outline' })}
-        >
-          {t('view_all')}
-          <ArrowUpRightIcon className="h-3.5 w-3.5" />
-        </Link>
-      </div>
+    <section className="w-full min-w-72 xl:max-w-lg">
+      <Card className="border">
+        <Card.Header className="items-start justify-between gap-4">
+          <div>
+            <Card.Title className="text-base font-semibold">
+              {t('title')}
+            </Card.Title>
+            <Card.Description className="mt-1">
+              {t('subtitle')}
+            </Card.Description>
+          </div>
+          <Link
+            href={INVOICES_PAGE}
+            className={buttonVariants({ size: 'sm', variant: 'outline' })}
+          >
+            {t('view_all')}
+            <ArrowUpRightIcon className="h-3.5 w-3.5" />
+          </Link>
+        </Card.Header>
 
-      {invoices.length ? (
-        <ul className="divide-default-200 mt-4 divide-y">
-          {invoices.map((invoice) => {
-            const isOverdue =
-              invoice.status === 'pending' &&
-              new Date(invoice.dueDate).getTime() < currentTimestamp;
-            const status: InvoiceStatus = isOverdue
-              ? 'overdue'
-              : (invoice.status as InvoiceStatus);
-            const color =
-              status === 'paid'
-                ? 'success'
-                : status === 'pending'
-                  ? 'warning'
-                  : 'danger';
+        <Card.Content>
+          {invoices.length ? (
+            <ul className="divide-default-200 divide-y">
+              {invoices.map((invoice) => {
+                const isOverdue =
+                  invoice.status === 'pending' &&
+                  new Date(invoice.dueDate).getTime() < currentTimestamp;
+                const status: InvoiceStatus = isOverdue
+                  ? 'overdue'
+                  : (invoice.status as InvoiceStatus);
+                const color =
+                  status === 'paid'
+                    ? 'success'
+                    : status === 'pending'
+                      ? 'warning'
+                      : 'danger';
 
-            return (
-              <li
-                key={invoice.id}
-                className="flex items-center gap-3 py-3.5 first:pt-2 last:pb-2"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="truncate text-sm font-medium">
-                      {invoice.name}
-                    </span>
-                    <Chip
-                      size="sm"
-                      color={color}
-                      variant="soft"
-                      className="h-5 shrink-0 text-[11px] font-medium"
-                    >
-                      {t(`statuses.${status}`)}
-                    </Chip>
-                  </div>
-                  <div className="text-muted mt-0.5 flex min-w-0 items-center gap-1.5 text-[11px]">
-                    <span className="shrink-0 tabular-nums">
-                      {invoice.invoiceId}
-                    </span>
-                    <span aria-hidden>·</span>
-                    <span className="shrink-0">
-                      {dateFormatter.format(new Date(invoice.date))}
-                    </span>
-                    {invoice.email && (
-                      <>
+                return (
+                  <li
+                    key={invoice.id}
+                    className="flex items-center gap-3 py-3.5 first:pt-0 last:pb-0"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="truncate text-sm font-medium">
+                          {invoice.name}
+                        </span>
+                        <Chip
+                          size="sm"
+                          color={color}
+                          variant="soft"
+                          className="h-5 shrink-0 text-[11px] font-medium"
+                        >
+                          {t(`statuses.${status}`)}
+                        </Chip>
+                      </div>
+                      <div className="text-muted mt-0.5 flex min-w-0 items-center gap-1.5 text-[11px]">
+                        <span className="shrink-0 tabular-nums">
+                          {invoice.invoiceId}
+                        </span>
                         <span aria-hidden>·</span>
-                        <span className="truncate">{invoice.email}</span>
-                      </>
-                    )}
-                  </div>
-                </div>
+                        <span className="shrink-0">
+                          {dateFormatter.format(new Date(invoice.date))}
+                        </span>
+                        {invoice.email && (
+                          <>
+                            <span aria-hidden>·</span>
+                            <span className="truncate">{invoice.email}</span>
+                          </>
+                        )}
+                      </div>
+                    </div>
 
-                <div className="shrink-0 text-right text-sm font-semibold tabular-nums">
-                  {getCurrencySymbol(currency)}
-                  {currencyFormatter.format(Number(invoice.totalAmount))}
-                </div>
-              </li>
-            );
-          })}
-        </ul>
-      ) : (
-        <EmptyState
-          className="min-h-[260px]"
-          title={t('empty_state.title')}
-          description={t('empty_state.description')}
-          actionLabel={t('empty_state.action')}
-          actionHref={ADD_NEW_INVOICE_PAGE}
-        />
-      )}
+                    <div className="shrink-0 text-right text-sm font-semibold tabular-nums">
+                      {getCurrencySymbol(currency)}
+                      {currencyFormatter.format(Number(invoice.totalAmount))}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <EmptyState
+              className="min-h-[260px]"
+              title={t('empty_state.title')}
+              description={t('empty_state.description')}
+              actionLabel={t('empty_state.action')}
+              actionHref={ADD_NEW_INVOICE_PAGE}
+            />
+          )}
+        </Card.Content>
+      </Card>
     </section>
   );
 };

--- a/client/src/components/dashboard/revenue-chart.tsx
+++ b/client/src/components/dashboard/revenue-chart.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@heroui/react';
 import { getTranslations } from 'next-intl/server';
 
 import { auth } from '@/auth';
@@ -18,12 +19,20 @@ const RevenueChart = async ({ userId }: Props) => {
   if (isResponseError(response)) throw new Error('Failed to fetch data');
 
   return (
-    <section className="border-default-200 flex w-full flex-col rounded-3xl border p-5 shadow-sm backdrop-blur-3xl sm:p-6">
-      <h2 className="text-base font-semibold">{t('title')}</h2>
-      <InvoiceDataBarChart
-        revenueByMonth={response.data.revenueByMonth}
-        currency={session?.user.currency}
-      />
+    <section className="w-full">
+      <Card className="w-full border">
+        <Card.Header>
+          <Card.Title className="text-base font-semibold">
+            {t('title')}
+          </Card.Title>
+        </Card.Header>
+        <Card.Content>
+          <InvoiceDataBarChart
+            revenueByMonth={response.data.revenueByMonth}
+            currency={session?.user.currency}
+          />
+        </Card.Content>
+      </Card>
     </section>
   );
 };

--- a/client/src/components/invoice/signing/invoice-signing-panel.tsx
+++ b/client/src/components/invoice/signing/invoice-signing-panel.tsx
@@ -19,6 +19,7 @@ import type { JSX } from 'react';
 import dynamic from 'next/dynamic';
 import { useTranslations } from 'next-intl';
 
+import IconContainer from '@/components/ui/icon-container';
 import SignaturePad from '@/components/signature-pad';
 
 const PDFDownloadLink = dynamic(
@@ -87,19 +88,16 @@ export default function InvoiceSigningPanel({
 
         <section className="flex flex-col gap-3">
           <div className="flex items-start gap-3">
-            <span
-              className={
-                isPaid
-                  ? 'bg-success/10 text-success grid h-9 w-9 shrink-0 place-items-center rounded-lg'
-                  : 'bg-secondary/10 text-secondary grid h-9 w-9 shrink-0 place-items-center rounded-lg'
-              }
+            <IconContainer
+              variant={isPaid ? 'success' : 'secondary'}
+              className="rounded-lg"
             >
               {isPaid ? (
                 <CheckCircleIcon className="h-5 w-5" />
               ) : (
                 <CreditCardIcon className="h-5 w-5" />
               )}
-            </span>
+            </IconContainer>
             <div className="min-w-0">
               <h3 className="text-sm font-semibold">
                 {isPaid
@@ -133,9 +131,9 @@ export default function InvoiceSigningPanel({
             {isSigned ? (
               <section className="flex flex-col gap-3">
                 <div className="flex items-start gap-3">
-                  <span className="bg-success/10 text-success grid h-9 w-9 shrink-0 place-items-center rounded-lg">
+                  <IconContainer variant="success" className="rounded-lg">
                     <CheckCircleIcon className="h-5 w-5" />
-                  </span>
+                  </IconContainer>
                   <div className="min-w-0">
                     <h3 className="text-sm font-semibold">
                       {t('signature_received_title')}

--- a/client/src/components/layout/guest-header.tsx
+++ b/client/src/components/layout/guest-header.tsx
@@ -46,7 +46,7 @@ export default function GuestHeader() {
           className={buttonVariants({
             variant: 'secondary',
             isIconOnly: true,
-            className: 'md:hidden'
+            className: 'flex size-10 items-center justify-center p-0 md:hidden'
           })}
         >
           <Bars3Icon className="h-5 w-5" />
@@ -54,14 +54,18 @@ export default function GuestHeader() {
         <DropdownPopover>
           <DropdownMenu>
             {navbarItems.map((item) => (
-              <DropdownItem key={item.key} href={getNavbarHref(item.href)}>
+              <DropdownItem
+                key={item.key}
+                href={getNavbarHref(item.href)}
+                className="justify-start text-left"
+              >
                 {t(item.key)}
               </DropdownItem>
             ))}
             <Separator />
             <DropdownItem
               key="create-invoice"
-              className="text-secondary"
+              className="text-secondary justify-start text-left"
               href={CREATE_INVOICE_PAGE}
             >
               {t('create_invoice')}
@@ -69,7 +73,7 @@ export default function GuestHeader() {
             <Separator />
             <DropdownItem
               href={LOGIN_PAGE}
-              className="text-muted flex items-center justify-center"
+              className="text-muted justify-start text-left"
               key="login"
             >
               {t('login')}
@@ -77,7 +81,7 @@ export default function GuestHeader() {
             <DropdownItem
               key="sign-up"
               href={SIGN_UP_PAGE}
-              className="text-muted flex items-center justify-center"
+              className="text-muted justify-start text-left"
             >
               {t('sign_up')}
             </DropdownItem>

--- a/client/src/components/profile/account-settings-form.tsx
+++ b/client/src/components/profile/account-settings-form.tsx
@@ -254,7 +254,7 @@ const AccountSettingsForm = ({ user }: Props) => {
         aria-label={t('a11y.form_label')}
         onSubmit={handleSubmit(onSubmit)}
       >
-        <Card className="w-full border bg-transparent">
+        <Card className="w-full border">
           <Card.Header className="px-6 py-4">
             <Card.Title className="text-2xl">{t('title')}</Card.Title>
           </Card.Header>

--- a/client/src/components/profile/bank-account-form.tsx
+++ b/client/src/components/profile/bank-account-form.tsx
@@ -203,7 +203,7 @@ export default function BankAccountForm({
   }
 
   return (
-    <Card className="w-full border bg-transparent">
+    <Card className="w-full border">
       <form aria-label={t('a11y.form_label')} onSubmit={handleSubmit(onSubmit)}>
         {formContent}
       </form>

--- a/client/src/components/profile/banking-information-form.tsx
+++ b/client/src/components/profile/banking-information-form.tsx
@@ -112,6 +112,7 @@ const BankingInformationForm = ({ user, bankAccounts }: Props) => {
     return (
       <Card
         key={id}
+        variant="secondary"
         className={cn('group col-span-2 border pt-0 lg:col-span-1', {
           'border-accent border-2': isSelected
         })}
@@ -197,7 +198,7 @@ const BankingInformationForm = ({ user, bankAccounts }: Props) => {
 
   return (
     <>
-      <Card className="w-full border bg-transparent">
+      <Card className="w-full border">
         <Card.Header className="flex flex-row items-center justify-between gap-4 px-6 py-4">
           <Card.Title className="text-2xl">{t('title')}</Card.Title>
           <Button variant="secondary" onPress={handleAddNewBankAccount}>

--- a/client/src/components/profile/change-password-form.tsx
+++ b/client/src/components/profile/change-password-form.tsx
@@ -120,7 +120,7 @@ export default function ChangePasswordForm({ userId }: Props) {
       aria-label={t('a11y.form_label')}
       onSubmit={handleSubmit(onSubmit)}
     >
-      <Card className="border bg-transparent">
+      <Card className="border">
         <Card.Header className="px-6 py-4">
           <Card.Title className="text-2xl">{t('title')}</Card.Title>
         </Card.Header>

--- a/client/src/components/profile/merchant-payment-status-card.tsx
+++ b/client/src/components/profile/merchant-payment-status-card.tsx
@@ -14,6 +14,7 @@ import type { MerchantPaymentStatus } from '@invoicetrackr/types';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
+import IconContainer from '@/components/ui/icon-container';
 import { createMerchantPaymentOnboardingSession } from '@/api/payment';
 import { isResponseError } from '@/lib/utils/error';
 
@@ -103,7 +104,7 @@ export default function MerchantPaymentStatusCard({
   };
 
   return (
-    <Card className="w-full border bg-transparent shadow-sm backdrop-blur-3xl">
+    <Card className="w-full border">
       <Card.Header className="flex flex-col items-start justify-between gap-6 px-6 py-4 md:flex-row md:items-start md:gap-12">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
@@ -151,11 +152,11 @@ export default function MerchantPaymentStatusCard({
         <div className="grid gap-3">
           {checks.map(({ key, enabled, icon: Icon }) => {
             return (
-              <Card className="border" key={key}>
+              <Card variant="secondary" className="border" key={key}>
                 <Card.Content className="flex flex-row items-start gap-3">
-                  <span className="bg-background-foreground text-muted border-default-100 grid h-9 w-9 shrink-0 place-items-center rounded-xl border">
+                  <IconContainer>
                     <Icon className="h-4 w-4" />
-                  </span>
+                  </IconContainer>
                   <div className="w-full min-w-0">
                     <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
                       <p className="text-foreground text-sm font-semibold leading-5">

--- a/client/src/components/profile/personal-information-form.tsx
+++ b/client/src/components/profile/personal-information-form.tsx
@@ -349,7 +349,7 @@ const PersonalInformationForm = ({
       encType="multipart/form-data"
       className="w-full"
     >
-      <Card className="w-full border bg-transparent">
+      <Card className="w-full border">
         {isOnboardingCard ? (
           <AuthCardHeader
             title={cardHeaderTitle!}

--- a/client/src/components/profile/subscription-status-card.tsx
+++ b/client/src/components/profile/subscription-status-card.tsx
@@ -11,10 +11,10 @@ import { User } from 'next-auth';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
+import IconContainer from '@/components/ui/icon-container';
 import { RENEW_SUBSCRIPTION_PAGE } from '@/lib/constants/pages';
 import { createBillingPortalSession } from '@/api/payment';
 import { formatLocalizedDate } from '@/lib/utils/date';
-import IconContainer from '@/components/ui/icon-container';
 import { isResponseError } from '@/lib/utils/error';
 
 type Props = {

--- a/client/src/components/profile/subscription-status-card.tsx
+++ b/client/src/components/profile/subscription-status-card.tsx
@@ -5,7 +5,7 @@ import {
   CheckCircleIcon,
   CreditCardIcon
 } from '@heroicons/react/24/outline';
-import { Button, Card, CardContent, Separator, cn } from '@heroui/react';
+import { Button, Card, CardContent, Separator } from '@heroui/react';
 import { useLocale, useTranslations } from 'next-intl';
 import { User } from 'next-auth';
 import { useRouter } from 'next/navigation';
@@ -14,6 +14,7 @@ import { useState } from 'react';
 import { RENEW_SUBSCRIPTION_PAGE } from '@/lib/constants/pages';
 import { createBillingPortalSession } from '@/api/payment';
 import { formatLocalizedDate } from '@/lib/utils/date';
+import IconContainer from '@/components/ui/icon-container';
 import { isResponseError } from '@/lib/utils/error';
 
 type Props = {
@@ -135,7 +136,7 @@ export default function SubscriptionStatusCard({
   };
 
   return (
-    <Card className="w-full flex-1 border bg-transparent shadow-sm backdrop-blur-3xl">
+    <Card className="w-full flex-1 border">
       <Card.Header className="flex flex-col items-start justify-between gap-5 px-6 py-4 md:flex-row">
         <div className="flex flex-col gap-2">
           <Card.Title className="text-2xl">{t('title')}</Card.Title>
@@ -171,14 +172,12 @@ export default function SubscriptionStatusCard({
       <CardContent className="grid gap-4 p-6 lg:grid-cols-[1fr_1fr]">
         <div className="p-1">
           <div className="flex items-start gap-3">
-            <span
-              className={cn(
-                'bg-success/10 text-success grid h-9 w-9 shrink-0 place-items-center rounded-lg',
-                { 'bg-danger/10 text-danger': !isActive }
-              )}
+            <IconContainer
+              variant={isActive ? 'success' : 'danger'}
+              className="rounded-lg"
             >
               <CheckCircleIcon className="h-5 w-5" />
-            </span>
+            </IconContainer>
             <div>
               <p className="section-eyebrow text-muted">{t('status_label')}</p>
               <p className="text-foreground mt-1 text-base font-semibold">
@@ -217,9 +216,9 @@ export default function SubscriptionStatusCard({
 
         <div className="p-1">
           <div className="flex items-start gap-3">
-            <span className="bg-secondary/15 text-secondary border-secondary/20 grid h-9 w-9 shrink-0 place-items-center rounded-xl border">
+            <IconContainer variant="secondary">
               <CreditCardIcon className="h-5 w-5" />
-            </span>
+            </IconContainer>
             <div>
               <p className="section-eyebrow text-muted">{t('billing_label')}</p>
               <p className="text-foreground mt-1 text-base font-semibold">

--- a/client/src/components/profile/user-nav-card.tsx
+++ b/client/src/components/profile/user-nav-card.tsx
@@ -113,7 +113,7 @@ export default function UserNavCard({ user }: Props) {
 
   return (
     <aside>
-      <Card className="flex max-h-min min-w-64 flex-col justify-between border bg-transparent py-5 sm:max-w-56">
+      <Card className="flex max-h-min min-w-64 flex-col justify-between border py-5 sm:max-w-56">
         <CardHeader className="flex-col">{renderUserDetails()}</CardHeader>
         <CardContent className="flex justify-center p-0 px-2">
           <Tabs

--- a/client/src/components/ui/icon-container.tsx
+++ b/client/src/components/ui/icon-container.tsx
@@ -1,0 +1,54 @@
+import { cn } from '@heroui/react';
+import type { ReactNode } from 'react';
+
+type IconContainerVariant =
+  | 'neutral'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'secondary'
+  | 'accent';
+
+type IconContainerSize = 'sm' | 'md' | 'lg';
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+  size?: IconContainerSize;
+  variant?: IconContainerVariant;
+};
+
+const sizeClasses: Record<IconContainerSize, string> = {
+  sm: 'h-7 w-7 rounded-lg',
+  md: 'h-9 w-9 rounded-xl',
+  lg: 'h-11 w-11 rounded-xl'
+};
+
+const variantClasses: Record<IconContainerVariant, string> = {
+  neutral: 'text-muted bg-default-foreground/5 border-muted/15',
+  success: 'text-success bg-success/10 border-success/20',
+  warning: 'text-warning bg-warning/10 border-warning/20',
+  danger: 'text-danger bg-danger/10 border-danger/20',
+  secondary: 'text-secondary bg-secondary/10 border-secondary/20',
+  accent: 'text-accent bg-accent/10 border-accent/20'
+};
+
+export default function IconContainer({
+  children,
+  className,
+  size = 'md',
+  variant = 'neutral'
+}: Props) {
+  return (
+    <span
+      className={cn(
+        'grid shrink-0 place-items-center border',
+        sizeClasses[size],
+        variantClasses[variant],
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/client/src/components/ui/icon-container.tsx
+++ b/client/src/components/ui/icon-container.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@heroui/react';
 import type { ReactNode } from 'react';
+import { cn } from '@heroui/react';
 
 type IconContainerVariant =
   | 'neutral'


### PR DESCRIPTION
### Overview

- Converts dashboard, profile, and home preview surfaces to default HeroUI Card styling with borders instead of transparent custom surfaces.
- Adds a reusable IconContainer component for the repeated icon-in-a-tinted-box pattern and applies it across dashboard, profile, signing, payment success, and auth UI.
- Keeps nested preview/card treatments on secondary or tertiary variants where appropriate.
- I ran git diff --cached --check before committing; full lint/typecheck/tests were not run per the repo handoff instructions.

### Additional changes

- Centers the mobile hamburger trigger and aligns mobile guest menu items consistently.