### PR TITLE
[REK-115] Add expense document upload foundation

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -77,7 +77,7 @@
     "home": {
         "hero": {
             "badge_label": "New",
-            "badge_text": "Built for individuali veikla",
+            "badge_text": "Upload expense documents",
             "title": "Invoice clients.",
             "title_accent": "Know what to set aside.",
             "subtitle": "A focused finance workspace for Lithuanian freelancers operating under individuali veikla pagal pažymą: invoices, clients, bank-transfer payment tracking, and income-journal exports.",

--- a/client/messages/lt.json
+++ b/client/messages/lt.json
@@ -77,10 +77,10 @@
     "home": {
         "hero": {
             "badge_label": "Nauja",
-            "badge_text": "Skirta individualiai veiklai",
+            "badge_text": "Įkelkite išlaidų dokumentus",
             "title": "Sąskaitos klientams.",
             "title_accent": "Aišku, kiek atsidėti.",
-            "subtitle": "Siaura finansų darbo vieta Lietuvos freelanceriams, dirbantiems pagal individualios veiklos pažymą: sąskaitos, klientai, bankinių pavedimų sekimas ir pajamų žurnalo eksportas.",
+            "subtitle": "Finansų valdymo įrankis Lietuvos specialistams, dirbantiems pagal individualios veiklos pažymą: sąskaitoms, klientams, bankiniams pavedimams ir pajamų žurnalo eksportui vienoje vietoje.",
             "cta_primary": "Sukurti nemokamą sąskaitą",
             "cta_secondary": "Sukurti paskyrą",
             "note": "Lietuvos individualiai veiklai · ne MB ar UAB apskaita"

--- a/client/src/api/expense.ts
+++ b/client/src/api/expense.ts
@@ -1,0 +1,83 @@
+import {
+  GetExpenseAttachmentResponse,
+  GetExpenseAttachmentsResponse,
+  MessageResponse,
+  PostExpenseAttachmentResponse,
+  UpdateExpenseAttachmentResponse
+} from '@invoicetrackr/types';
+
+import api from './api-instance';
+
+export const getExpenseAttachments = async (
+  userId: number,
+  expenseId: number
+) =>
+  await api.get<GetExpenseAttachmentsResponse>(
+    `/api/${userId}/expenses/${expenseId}/attachments`
+  );
+
+export const getExpenseAttachment = async ({
+  userId,
+  expenseId,
+  attachmentId
+}: {
+  userId: number;
+  expenseId: number;
+  attachmentId: number;
+}) =>
+  await api.get<GetExpenseAttachmentResponse>(
+    `/api/${userId}/expenses/${expenseId}/attachments/${attachmentId}`
+  );
+
+export const uploadExpenseAttachment = async ({
+  userId,
+  expenseId,
+  file
+}: {
+  userId: number;
+  expenseId: number;
+  file: File;
+}) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  return await api.post<PostExpenseAttachmentResponse>(
+    `/api/${userId}/expenses/${expenseId}/attachments`,
+    formData,
+    { headers: { 'Content-Type': 'multipart/form-data' } }
+  );
+};
+
+export const replaceExpenseAttachment = async ({
+  userId,
+  expenseId,
+  attachmentId,
+  file
+}: {
+  userId: number;
+  expenseId: number;
+  attachmentId: number;
+  file: File;
+}) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  return await api.put<UpdateExpenseAttachmentResponse>(
+    `/api/${userId}/expenses/${expenseId}/attachments/${attachmentId}`,
+    formData,
+    { headers: { 'Content-Type': 'multipart/form-data' } }
+  );
+};
+
+export const deleteExpenseAttachment = async ({
+  userId,
+  expenseId,
+  attachmentId
+}: {
+  userId: number;
+  expenseId: number;
+  attachmentId: number;
+}) =>
+  await api.delete<MessageResponse>(
+    `/api/${userId}/expenses/${expenseId}/attachments/${attachmentId}`
+  );

--- a/server/drizzle/0034_rek_115_expense_document_uploads.sql
+++ b/server/drizzle/0034_rek_115_expense_document_uploads.sql
@@ -1,0 +1,74 @@
+CREATE TABLE IF NOT EXISTS "expenses" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "user_id" integer NOT NULL,
+  "expense_date" date NOT NULL,
+  "payment_date" date,
+  "supplier" varchar(255) NOT NULL,
+  "document_number" varchar(255),
+  "description" text NOT NULL,
+  "category" varchar(100) NOT NULL,
+  "currency" varchar(3) DEFAULT 'eur' NOT NULL,
+  "total_amount" numeric(10, 2) NOT NULL,
+  "eur_amount" numeric(10, 2) NOT NULL,
+  "vat_amount" numeric(10, 2),
+  "business_use_percentage" numeric(5, 2) DEFAULT '100' NOT NULL,
+  "deductible_amount" numeric(10, 2) NOT NULL,
+  "payment_method" varchar(50),
+  "notes" text,
+  "deleted_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "expense_attachments" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "expense_id" integer NOT NULL,
+  "storage_provider" varchar(50) DEFAULT 'cloudinary' NOT NULL,
+  "storage_key" varchar(255) NOT NULL,
+  "secure_url" text NOT NULL,
+  "resource_type" varchar(50) DEFAULT 'auto' NOT NULL,
+  "original_file_name" text NOT NULL,
+  "sanitized_file_name" text NOT NULL,
+  "mime_type" varchar(100) NOT NULL,
+  "file_size" integer NOT NULL,
+  "checksum" varchar(64) NOT NULL,
+  "malware_scan_status" varchar(50) DEFAULT 'not_configured' NOT NULL,
+  "deleted_at" timestamp with time zone,
+  "uploaded_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "expense_attachment_events" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "user_id" integer NOT NULL,
+  "expense_id" integer NOT NULL,
+  "attachment_id" integer,
+  "action" varchar(50) NOT NULL,
+  "previous_value" jsonb,
+  "new_value" jsonb,
+  "created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+ALTER TABLE "expenses" ADD CONSTRAINT "fk_expenses_user_id" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "expense_attachments" ADD CONSTRAINT "fk_expense_attachments_expense_id" FOREIGN KEY ("expense_id") REFERENCES "public"."expenses"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "expense_attachment_events" ADD CONSTRAINT "fk_expense_attachment_events_user_id" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "expense_attachment_events" ADD CONSTRAINT "fk_expense_attachment_events_expense_id" FOREIGN KEY ("expense_id") REFERENCES "public"."expenses"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "expense_attachment_events" ADD CONSTRAINT "fk_expense_attachment_events_attachment_id" FOREIGN KEY ("attachment_id") REFERENCES "public"."expense_attachments"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "expenses" ADD CONSTRAINT "expenses_business_use_percentage_check" CHECK ("expenses"."business_use_percentage" >= 0 AND "expenses"."business_use_percentage" <= 100);
+--> statement-breakpoint
+ALTER TABLE "expenses" ADD CONSTRAINT "expenses_total_amount_check" CHECK ("expenses"."total_amount" >= 0);
+--> statement-breakpoint
+ALTER TABLE "expenses" ADD CONSTRAINT "expenses_eur_amount_check" CHECK ("expenses"."eur_amount" >= 0);
+--> statement-breakpoint
+ALTER TABLE "expenses" ADD CONSTRAINT "expenses_deductible_amount_check" CHECK ("expenses"."deductible_amount" >= 0);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "expenses_user_date_idx" ON "expenses" USING btree ("user_id", "expense_date");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "expense_attachments_expense_id_idx" ON "expense_attachments" USING btree ("expense_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "expense_attachments_checksum_expense_key" ON "expense_attachments" USING btree ("expense_id", "checksum") WHERE "deleted_at" IS NULL;

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1783299600000,
       "tag": "0033_remove_invoice_corrections",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1783305600000,
+      "tag": "0034_rek_115_expense_document_uploads",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,6 +16,7 @@ import clientRoutes from './routes/client';
 import { cloudinaryConfig } from './config/cloudinary';
 import contactRoutes from './routes/contact';
 import { errorHandler } from './utils/error';
+import expenseRoutes from './routes/expense';
 import { getPgVersion } from './database/db';
 import i18n from './plugins/i18n';
 import invoiceRoutes from './routes/invoice';
@@ -82,6 +83,7 @@ server.setSerializerCompiler(serializerCompiler);
 // Register Routes
 server.register(webhookRoutes);
 server.register(invoiceRoutes);
+server.register(expenseRoutes);
 server.register(clientRoutes);
 server.register(userRoutes);
 server.register(bankingInformationRoutes);

--- a/server/src/controllers/expense.ts
+++ b/server/src/controllers/expense.ts
@@ -1,0 +1,339 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { UploadApiResponse, v2 as cloudinary } from 'cloudinary';
+import { MultipartFile } from '@fastify/multipart';
+import crypto from 'crypto';
+import path from 'path';
+import { useI18n } from 'fastify-i18n';
+
+import { BadRequestError, NotFoundError } from '../utils/error';
+import {
+  deleteExpenseAttachmentFromDb,
+  getExpenseAttachmentFromDb,
+  getExpenseAttachmentsFromDb,
+  getExpenseFromDb,
+  insertExpenseAttachmentInDb,
+  replaceExpenseAttachmentInDb
+} from '../database/expense';
+import { SelectExpenseAttachment } from '../database/schema';
+
+const allowedMimeTypes = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png'
+]);
+const maxExpenseAttachmentSizeBytes = 10 * 1024 * 1024;
+
+const sanitizeFileName = (fileName: string) => {
+  const extension = path.extname(fileName).toLowerCase();
+  const baseName = path.basename(fileName, extension);
+  const safeBaseName = baseName
+    .normalize('NFKD')
+    .replace(/[^\w-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 100);
+
+  return `${safeBaseName || 'expense-document'}${extension}`;
+};
+
+const getChecksum = (buffer: Buffer) =>
+  crypto.createHash('sha256').update(buffer).digest('hex');
+
+const getSignedAttachmentUrl = (
+  attachment: SelectExpenseAttachment,
+  disposition?: 'attachment'
+) =>
+  cloudinary.url(attachment.storageKey, {
+    expires_at: Math.floor(Date.now() / 1000) + 300,
+    resource_type: attachment.resourceType,
+    secure: true,
+    sign_url: true,
+    type: 'authenticated',
+    ...(disposition ? { flags: disposition } : {})
+  });
+
+const mapAttachmentForResponse = (attachment: SelectExpenseAttachment) => ({
+  id: attachment.id,
+  expenseId: attachment.expenseId,
+  storageProvider: attachment.storageProvider,
+  resourceType: attachment.resourceType,
+  originalFileName: attachment.originalFileName,
+  sanitizedFileName: attachment.sanitizedFileName,
+  mimeType: attachment.mimeType,
+  fileSize: attachment.fileSize,
+  checksum: attachment.checksum,
+  malwareScanStatus: attachment.malwareScanStatus,
+  uploadedAt: attachment.uploadedAt,
+  updatedAt: attachment.updatedAt,
+  previewUrl: getSignedAttachmentUrl(attachment),
+  downloadUrl: getSignedAttachmentUrl(attachment, 'attachment')
+});
+
+const readAndValidateAttachmentFile = async (
+  file: MultipartFile | undefined,
+  unableToUploadMessage: string,
+  invalidTypeMessage: string,
+  tooLargeMessage: string
+) => {
+  if (!file) throw new BadRequestError(unableToUploadMessage);
+
+  if (!allowedMimeTypes.has(file.mimetype)) {
+    throw new BadRequestError(invalidTypeMessage);
+  }
+
+  const buffer = await file.toBuffer();
+
+  if (buffer.length > maxExpenseAttachmentSizeBytes) {
+    throw new BadRequestError(tooLargeMessage);
+  }
+
+  return {
+    buffer,
+    checksum: getChecksum(buffer),
+    sanitizedFileName: sanitizeFileName(file.filename),
+    originalFileName: file.filename,
+    mimeType: file.mimetype,
+    fileSize: buffer.length
+  };
+};
+
+const uploadExpenseAttachment = async ({
+  userId,
+  expenseId,
+  file
+}: {
+  userId: number;
+  expenseId: number;
+  file: {
+    buffer: Buffer;
+    mimeType: string;
+    sanitizedFileName: string;
+  };
+}): Promise<UploadApiResponse> => {
+  const uploadedAttachment = await cloudinary.uploader.upload(
+    `data:${file.mimeType};base64,${file.buffer.toString('base64')}`,
+    {
+      folder: `invoicetrackr/expense-documents/${userId}/${expenseId}`,
+      resource_type: 'auto',
+      type: 'authenticated',
+      use_filename: true,
+      unique_filename: true,
+      filename_override: file.sanitizedFileName,
+      access_mode: 'authenticated'
+    }
+  );
+
+  if (!uploadedAttachment) {
+    throw new BadRequestError('Unable to upload expense document');
+  }
+
+  return uploadedAttachment;
+};
+
+const assertOwnedExpense = async ({
+  userId,
+  expenseId,
+  notFoundMessage
+}: {
+  userId: number;
+  expenseId: number;
+  notFoundMessage: string;
+}) => {
+  const expense = await getExpenseFromDb(userId, expenseId);
+
+  if (!expense) throw new NotFoundError(notFoundMessage);
+
+  return expense;
+};
+
+export const getExpenseAttachments = async (
+  req: FastifyRequest<{ Params: { userId: string; expenseId: string } }>,
+  reply: FastifyReply
+) => {
+  const userId = Number(req.params.userId);
+  const expenseId = Number(req.params.expenseId);
+  const i18n = await useI18n(req);
+
+  await assertOwnedExpense({
+    userId,
+    expenseId,
+    notFoundMessage: i18n.t('error.expense.notFound')
+  });
+
+  const attachments = await getExpenseAttachmentsFromDb(userId, expenseId);
+
+  reply.status(200).send({
+    attachments: attachments.map(mapAttachmentForResponse)
+  });
+};
+
+export const getExpenseAttachment = async (
+  req: FastifyRequest<{
+    Params: { userId: string; expenseId: string; attachmentId: string };
+  }>,
+  reply: FastifyReply
+) => {
+  const userId = Number(req.params.userId);
+  const expenseId = Number(req.params.expenseId);
+  const attachmentId = Number(req.params.attachmentId);
+  const i18n = await useI18n(req);
+
+  const attachment = await getExpenseAttachmentFromDb(
+    userId,
+    expenseId,
+    attachmentId
+  );
+
+  if (!attachment) {
+    throw new NotFoundError(i18n.t('error.expenseAttachment.notFound'));
+  }
+
+  reply.status(200).send({ attachment: mapAttachmentForResponse(attachment) });
+};
+
+export const postExpenseAttachment = async (
+  req: FastifyRequest<{
+    Params: { userId: string; expenseId: string };
+    Body: { file?: MultipartFile };
+  }>,
+  reply: FastifyReply
+) => {
+  const userId = Number(req.params.userId);
+  const expenseId = Number(req.params.expenseId);
+  const i18n = await useI18n(req);
+
+  await assertOwnedExpense({
+    userId,
+    expenseId,
+    notFoundMessage: i18n.t('error.expense.notFound')
+  });
+
+  const file = await readAndValidateAttachmentFile(
+    req.body?.file,
+    i18n.t('error.expenseAttachment.unableToUpload'),
+    i18n.t('error.expenseAttachment.invalidType'),
+    i18n.t('error.expenseAttachment.tooLarge')
+  );
+  const uploadedAttachment = await uploadExpenseAttachment({
+    userId,
+    expenseId,
+    file
+  });
+  const attachment = await insertExpenseAttachmentInDb({
+    userId,
+    attachment: {
+      expenseId,
+      storageKey: uploadedAttachment.public_id,
+      secureUrl: uploadedAttachment.secure_url,
+      resourceType: uploadedAttachment.resource_type,
+      originalFileName: file.originalFileName,
+      sanitizedFileName: file.sanitizedFileName,
+      mimeType: file.mimeType,
+      fileSize: file.fileSize,
+      checksum: file.checksum,
+      malwareScanStatus: 'not_configured'
+    }
+  });
+
+  if (!attachment) {
+    throw new BadRequestError(i18n.t('error.expenseAttachment.unableToUpload'));
+  }
+
+  reply.status(201).send({
+    attachment: mapAttachmentForResponse(attachment),
+    message: i18n.t('success.expenseAttachment.uploaded')
+  });
+};
+
+export const replaceExpenseAttachment = async (
+  req: FastifyRequest<{
+    Params: { userId: string; expenseId: string; attachmentId: string };
+    Body: { file?: MultipartFile };
+  }>,
+  reply: FastifyReply
+) => {
+  const userId = Number(req.params.userId);
+  const expenseId = Number(req.params.expenseId);
+  const attachmentId = Number(req.params.attachmentId);
+  const i18n = await useI18n(req);
+  const existingAttachment = await getExpenseAttachmentFromDb(
+    userId,
+    expenseId,
+    attachmentId
+  );
+
+  if (!existingAttachment) {
+    throw new NotFoundError(i18n.t('error.expenseAttachment.notFound'));
+  }
+
+  const file = await readAndValidateAttachmentFile(
+    req.body?.file,
+    i18n.t('error.expenseAttachment.unableToUpload'),
+    i18n.t('error.expenseAttachment.invalidType'),
+    i18n.t('error.expenseAttachment.tooLarge')
+  );
+  const uploadedAttachment = await uploadExpenseAttachment({
+    userId,
+    expenseId,
+    file
+  });
+  const attachment = await replaceExpenseAttachmentInDb({
+    userId,
+    expenseId,
+    attachmentId,
+    attachment: {
+      storageKey: uploadedAttachment.public_id,
+      secureUrl: uploadedAttachment.secure_url,
+      resourceType: uploadedAttachment.resource_type,
+      originalFileName: file.originalFileName,
+      sanitizedFileName: file.sanitizedFileName,
+      mimeType: file.mimeType,
+      fileSize: file.fileSize,
+      checksum: file.checksum,
+      malwareScanStatus: 'not_configured'
+    }
+  });
+
+  await cloudinary.uploader.destroy(existingAttachment.storageKey, {
+    resource_type: existingAttachment.resourceType,
+    type: 'authenticated'
+  });
+
+  if (!attachment) {
+    throw new BadRequestError(i18n.t('error.expenseAttachment.unableToUpload'));
+  }
+
+  reply.status(200).send({
+    attachment: mapAttachmentForResponse(attachment),
+    message: i18n.t('success.expenseAttachment.replaced')
+  });
+};
+
+export const deleteExpenseAttachment = async (
+  req: FastifyRequest<{
+    Params: { userId: string; expenseId: string; attachmentId: string };
+  }>,
+  reply: FastifyReply
+) => {
+  const userId = Number(req.params.userId);
+  const expenseId = Number(req.params.expenseId);
+  const attachmentId = Number(req.params.attachmentId);
+  const i18n = await useI18n(req);
+  const deletedAttachment = await deleteExpenseAttachmentFromDb(
+    userId,
+    expenseId,
+    attachmentId
+  );
+
+  if (!deletedAttachment) {
+    throw new NotFoundError(i18n.t('error.expenseAttachment.notFound'));
+  }
+
+  await cloudinary.uploader.destroy(deletedAttachment.storageKey, {
+    resource_type: deletedAttachment.resourceType,
+    type: 'authenticated'
+  });
+
+  reply
+    .status(200)
+    .send({ message: i18n.t('success.expenseAttachment.removed') });
+};

--- a/server/src/database/expense.ts
+++ b/server/src/database/expense.ts
@@ -1,0 +1,248 @@
+import { and, desc, eq, isNull } from 'drizzle-orm';
+
+import {
+  InsertExpenseAttachment,
+  SelectExpense,
+  SelectExpenseAttachment,
+  expenseAttachmentEventsTable,
+  expenseAttachmentsTable,
+  expensesTable
+} from './schema';
+import { db } from './db';
+
+const activeAttachmentWhere = (
+  userId: number,
+  expenseId: number,
+  attachmentId?: number
+) => {
+  const conditions = [
+    eq(expensesTable.userId, userId),
+    eq(expensesTable.id, expenseId),
+    isNull(expensesTable.deletedAt),
+    isNull(expenseAttachmentsTable.deletedAt)
+  ];
+
+  if (attachmentId) {
+    conditions.push(eq(expenseAttachmentsTable.id, attachmentId));
+  }
+
+  return and(...conditions);
+};
+
+export const getExpenseFromDb = async (
+  userId: number,
+  expenseId: number
+): Promise<SelectExpense | undefined> => {
+  const expenses = await db
+    .select()
+    .from(expensesTable)
+    .where(
+      and(
+        eq(expensesTable.userId, userId),
+        eq(expensesTable.id, expenseId),
+        isNull(expensesTable.deletedAt)
+      )
+    );
+
+  return expenses.at(0);
+};
+
+export const getExpenseAttachmentsFromDb = async (
+  userId: number,
+  expenseId: number
+): Promise<Array<SelectExpenseAttachment>> => {
+  const attachments = await db
+    .select({
+      id: expenseAttachmentsTable.id,
+      expenseId: expenseAttachmentsTable.expenseId,
+      storageProvider: expenseAttachmentsTable.storageProvider,
+      storageKey: expenseAttachmentsTable.storageKey,
+      secureUrl: expenseAttachmentsTable.secureUrl,
+      resourceType: expenseAttachmentsTable.resourceType,
+      originalFileName: expenseAttachmentsTable.originalFileName,
+      sanitizedFileName: expenseAttachmentsTable.sanitizedFileName,
+      mimeType: expenseAttachmentsTable.mimeType,
+      fileSize: expenseAttachmentsTable.fileSize,
+      checksum: expenseAttachmentsTable.checksum,
+      malwareScanStatus: expenseAttachmentsTable.malwareScanStatus,
+      deletedAt: expenseAttachmentsTable.deletedAt,
+      uploadedAt: expenseAttachmentsTable.uploadedAt,
+      updatedAt: expenseAttachmentsTable.updatedAt
+    })
+    .from(expenseAttachmentsTable)
+    .innerJoin(
+      expensesTable,
+      eq(expenseAttachmentsTable.expenseId, expensesTable.id)
+    )
+    .where(activeAttachmentWhere(userId, expenseId))
+    .orderBy(desc(expenseAttachmentsTable.uploadedAt));
+
+  return attachments;
+};
+
+export const getExpenseAttachmentFromDb = async (
+  userId: number,
+  expenseId: number,
+  attachmentId: number
+): Promise<SelectExpenseAttachment | undefined> => {
+  const attachments = await db
+    .select({
+      id: expenseAttachmentsTable.id,
+      expenseId: expenseAttachmentsTable.expenseId,
+      storageProvider: expenseAttachmentsTable.storageProvider,
+      storageKey: expenseAttachmentsTable.storageKey,
+      secureUrl: expenseAttachmentsTable.secureUrl,
+      resourceType: expenseAttachmentsTable.resourceType,
+      originalFileName: expenseAttachmentsTable.originalFileName,
+      sanitizedFileName: expenseAttachmentsTable.sanitizedFileName,
+      mimeType: expenseAttachmentsTable.mimeType,
+      fileSize: expenseAttachmentsTable.fileSize,
+      checksum: expenseAttachmentsTable.checksum,
+      malwareScanStatus: expenseAttachmentsTable.malwareScanStatus,
+      deletedAt: expenseAttachmentsTable.deletedAt,
+      uploadedAt: expenseAttachmentsTable.uploadedAt,
+      updatedAt: expenseAttachmentsTable.updatedAt
+    })
+    .from(expenseAttachmentsTable)
+    .innerJoin(
+      expensesTable,
+      eq(expenseAttachmentsTable.expenseId, expensesTable.id)
+    )
+    .where(activeAttachmentWhere(userId, expenseId, attachmentId));
+
+  return attachments.at(0);
+};
+
+export const insertExpenseAttachmentInDb = async ({
+  userId,
+  attachment
+}: {
+  userId: number;
+  attachment: InsertExpenseAttachment;
+}): Promise<SelectExpenseAttachment | undefined> => {
+  const attachments = await db
+    .insert(expenseAttachmentsTable)
+    .values(attachment)
+    .returning();
+
+  const insertedAttachment = attachments.at(0);
+
+  if (insertedAttachment) {
+    await insertExpenseAttachmentEventInDb({
+      userId,
+      expenseId: insertedAttachment.expenseId,
+      attachmentId: insertedAttachment.id,
+      action: 'created',
+      newValue: insertedAttachment
+    });
+  }
+
+  return insertedAttachment;
+};
+
+export const replaceExpenseAttachmentInDb = async ({
+  userId,
+  expenseId,
+  attachmentId,
+  attachment
+}: {
+  userId: number;
+  expenseId: number;
+  attachmentId: number;
+  attachment: Omit<InsertExpenseAttachment, 'expenseId'>;
+}): Promise<SelectExpenseAttachment | undefined> => {
+  const previousAttachment = await getExpenseAttachmentFromDb(
+    userId,
+    expenseId,
+    attachmentId
+  );
+
+  if (!previousAttachment) return;
+
+  const attachments = await db
+    .update(expenseAttachmentsTable)
+    .set({
+      ...attachment,
+      updatedAt: new Date().toISOString()
+    })
+    .where(eq(expenseAttachmentsTable.id, attachmentId))
+    .returning();
+
+  const updatedAttachment = attachments.at(0);
+
+  if (updatedAttachment) {
+    await insertExpenseAttachmentEventInDb({
+      userId,
+      expenseId,
+      attachmentId,
+      action: 'replaced',
+      previousValue: previousAttachment,
+      newValue: updatedAttachment
+    });
+  }
+
+  return updatedAttachment;
+};
+
+export const deleteExpenseAttachmentFromDb = async (
+  userId: number,
+  expenseId: number,
+  attachmentId: number
+): Promise<SelectExpenseAttachment | undefined> => {
+  const previousAttachment = await getExpenseAttachmentFromDb(
+    userId,
+    expenseId,
+    attachmentId
+  );
+
+  if (!previousAttachment) return;
+
+  const attachments = await db
+    .update(expenseAttachmentsTable)
+    .set({
+      deletedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    })
+    .where(eq(expenseAttachmentsTable.id, attachmentId))
+    .returning();
+
+  const deletedAttachment = attachments.at(0);
+
+  if (deletedAttachment) {
+    await insertExpenseAttachmentEventInDb({
+      userId,
+      expenseId,
+      attachmentId,
+      action: 'removed',
+      previousValue: previousAttachment,
+      newValue: deletedAttachment
+    });
+  }
+
+  return deletedAttachment;
+};
+
+export const insertExpenseAttachmentEventInDb = async ({
+  userId,
+  expenseId,
+  attachmentId,
+  action,
+  previousValue,
+  newValue
+}: {
+  userId: number;
+  expenseId: number;
+  attachmentId?: number;
+  action: 'created' | 'replaced' | 'removed';
+  previousValue?: unknown;
+  newValue?: unknown;
+}) => {
+  await db.insert(expenseAttachmentEventsTable).values({
+    userId,
+    expenseId,
+    attachmentId,
+    action,
+    previousValue,
+    newValue
+  });
+};

--- a/server/src/database/schema.ts
+++ b/server/src/database/schema.ts
@@ -5,12 +5,14 @@ import {
   foreignKey,
   index,
   integer,
+  jsonb,
   numeric,
   pgTable,
   serial,
   text,
   timestamp,
   unique,
+  uniqueIndex,
   varchar
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
@@ -385,6 +387,156 @@ export const bankingInformationTable = pgTable(
   ]
 );
 
+export const expensesTable = pgTable(
+  'expenses',
+  {
+    id: serial().primaryKey().notNull(),
+    userId: integer('user_id').notNull(),
+    expenseDate: date('expense_date').notNull(),
+    paymentDate: date('payment_date'),
+    supplier: varchar({ length: 255 }).notNull(),
+    documentNumber: varchar('document_number', { length: 255 }),
+    description: text().notNull(),
+    category: varchar({ length: 100 }).notNull(),
+    currency: varchar({ length: 3 }).default('eur').notNull(),
+    totalAmount: numeric('total_amount', {
+      precision: 10,
+      scale: 2
+    }).notNull(),
+    eurAmount: numeric('eur_amount', {
+      precision: 10,
+      scale: 2
+    }).notNull(),
+    vatAmount: numeric('vat_amount', {
+      precision: 10,
+      scale: 2
+    }),
+    businessUsePercentage: numeric('business_use_percentage', {
+      precision: 5,
+      scale: 2
+    })
+      .default('100')
+      .notNull(),
+    deductibleAmount: numeric('deductible_amount', {
+      precision: 10,
+      scale: 2
+    }).notNull(),
+    paymentMethod: varchar('payment_method', { length: 50 }),
+    notes: text(),
+    deletedAt: timestamp('deleted_at', {
+      withTimezone: true,
+      mode: 'string'
+    }),
+    createdAt: timestamp('created_at', {
+      withTimezone: true,
+      mode: 'string'
+    }).default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: timestamp('updated_at', {
+      withTimezone: true,
+      mode: 'string'
+    }).default(sql`CURRENT_TIMESTAMP`)
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [usersTable.id],
+      name: 'fk_expenses_user_id'
+    }).onDelete('cascade'),
+    index('expenses_user_date_idx').on(table.userId, table.expenseDate),
+    check(
+      'expenses_business_use_percentage_check',
+      sql`${table.businessUsePercentage} >= 0 AND ${table.businessUsePercentage} <= 100`
+    ),
+    check('expenses_total_amount_check', sql`${table.totalAmount} >= 0`),
+    check('expenses_eur_amount_check', sql`${table.eurAmount} >= 0`),
+    check(
+      'expenses_deductible_amount_check',
+      sql`${table.deductibleAmount} >= 0`
+    )
+  ]
+);
+
+export const expenseAttachmentsTable = pgTable(
+  'expense_attachments',
+  {
+    id: serial().primaryKey().notNull(),
+    expenseId: integer('expense_id').notNull(),
+    storageProvider: varchar('storage_provider', { length: 50 })
+      .default('cloudinary')
+      .notNull(),
+    storageKey: varchar('storage_key', { length: 255 }).notNull(),
+    secureUrl: text('secure_url').notNull(),
+    resourceType: varchar('resource_type', { length: 50 })
+      .default('auto')
+      .notNull(),
+    originalFileName: text('original_file_name').notNull(),
+    sanitizedFileName: text('sanitized_file_name').notNull(),
+    mimeType: varchar('mime_type', { length: 100 }).notNull(),
+    fileSize: integer('file_size').notNull(),
+    checksum: varchar({ length: 64 }).notNull(),
+    malwareScanStatus: varchar('malware_scan_status', { length: 50 })
+      .default('not_configured')
+      .notNull(),
+    deletedAt: timestamp('deleted_at', {
+      withTimezone: true,
+      mode: 'string'
+    }),
+    uploadedAt: timestamp('uploaded_at', {
+      withTimezone: true,
+      mode: 'string'
+    }).default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: timestamp('updated_at', {
+      withTimezone: true,
+      mode: 'string'
+    }).default(sql`CURRENT_TIMESTAMP`)
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.expenseId],
+      foreignColumns: [expensesTable.id],
+      name: 'fk_expense_attachments_expense_id'
+    }).onDelete('cascade'),
+    index('expense_attachments_expense_id_idx').on(table.expenseId),
+    uniqueIndex('expense_attachments_checksum_expense_key')
+      .on(table.expenseId, table.checksum)
+      .where(sql`${table.deletedAt} IS NULL`)
+  ]
+);
+
+export const expenseAttachmentEventsTable = pgTable(
+  'expense_attachment_events',
+  {
+    id: serial().primaryKey().notNull(),
+    userId: integer('user_id').notNull(),
+    expenseId: integer('expense_id').notNull(),
+    attachmentId: integer('attachment_id'),
+    action: varchar({ length: 50 }).notNull(),
+    previousValue: jsonb('previous_value'),
+    newValue: jsonb('new_value'),
+    createdAt: timestamp('created_at', {
+      withTimezone: true,
+      mode: 'string'
+    }).default(sql`CURRENT_TIMESTAMP`)
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [usersTable.id],
+      name: 'fk_expense_attachment_events_user_id'
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.expenseId],
+      foreignColumns: [expensesTable.id],
+      name: 'fk_expense_attachment_events_expense_id'
+    }).onDelete('cascade'),
+    foreignKey({
+      columns: [table.attachmentId],
+      foreignColumns: [expenseAttachmentsTable.id],
+      name: 'fk_expense_attachment_events_attachment_id'
+    }).onDelete('set null')
+  ]
+);
+
 export const passwordResetTokensTable = pgTable('password_reset_tokens', {
   id: serial().primaryKey().notNull(),
   userId: integer('user_id')
@@ -449,3 +601,16 @@ export type SelectUser = typeof usersTable.$inferSelect;
 
 export type InsertClient = typeof clientsTable.$inferInsert;
 export type SelectClient = typeof clientsTable.$inferSelect;
+
+export type InsertExpense = typeof expensesTable.$inferInsert;
+export type SelectExpense = typeof expensesTable.$inferSelect;
+
+export type InsertExpenseAttachment =
+  typeof expenseAttachmentsTable.$inferInsert;
+export type SelectExpenseAttachment =
+  typeof expenseAttachmentsTable.$inferSelect;
+
+export type InsertExpenseAttachmentEvent =
+  typeof expenseAttachmentEventsTable.$inferInsert;
+export type SelectExpenseAttachmentEvent =
+  typeof expenseAttachmentEventsTable.$inferSelect;

--- a/server/src/locales/en.ts
+++ b/server/src/locales/en.ts
@@ -207,6 +207,11 @@ export default {
       updated: 'Bank account updated successfully',
       deleted: 'Bank account deleted successfully'
     },
+    expenseAttachment: {
+      uploaded: 'Expense document uploaded successfully',
+      replaced: 'Expense document replaced successfully',
+      removed: 'Expense document removed successfully'
+    },
     contact: {
       messageSent: 'Message sent successfully'
     }
@@ -277,6 +282,15 @@ export default {
       unableToCreate: 'Unable to add client',
       unableToUpdate: 'Unable to update client',
       unableToDelete: 'Unable to delete client'
+    },
+    expense: {
+      notFound: 'Expense not found'
+    },
+    expenseAttachment: {
+      notFound: 'Expense document not found',
+      unableToUpload: 'Unable to upload expense document',
+      invalidType: 'Upload a PDF, JPEG, or PNG document',
+      tooLarge: 'Expense document must be 10 MB or smaller'
     },
     bankAccount: {
       notFound: 'Bank account not found',

--- a/server/src/locales/lt.ts
+++ b/server/src/locales/lt.ts
@@ -212,6 +212,11 @@ export default {
       updated: 'Banko sąskaita atnaujinta sėkmingai',
       deleted: 'Banko sąskaita ištrinta sėkmingai'
     },
+    expenseAttachment: {
+      uploaded: 'Išlaidų dokumentas įkeltas sėkmingai',
+      replaced: 'Išlaidų dokumentas pakeistas sėkmingai',
+      removed: 'Išlaidų dokumentas pašalintas sėkmingai'
+    },
     contact: {
       messageSent: 'Žinutė išsiųsta sėkmingai'
     }
@@ -282,6 +287,15 @@ export default {
       unableToCreate: 'Nepavyko pridėti kliento',
       unableToUpdate: 'Nepavyko atnaujinti kliento',
       unableToDelete: 'Nepavyko ištrinti kliento'
+    },
+    expense: {
+      notFound: 'Išlaidų įrašas nerastas'
+    },
+    expenseAttachment: {
+      notFound: 'Išlaidų dokumentas nerastas',
+      unableToUpload: 'Nepavyko įkelti išlaidų dokumento',
+      invalidType: 'Įkelkite PDF, JPEG arba PNG dokumentą',
+      tooLarge: 'Išlaidų dokumentas turi būti ne didesnis nei 10 MB'
     },
     bankAccount: {
       notFound: 'Banko sąskaita nerasta',

--- a/server/src/options/expense.ts
+++ b/server/src/options/expense.ts
@@ -1,0 +1,85 @@
+import {
+  expenseAttachmentParamsSchema,
+  expenseParamsSchema,
+  getExpenseAttachmentResponseSchema,
+  getExpenseAttachmentsResponseSchema,
+  messageResponseSchema,
+  postExpenseAttachmentResponseSchema,
+  updateExpenseAttachmentResponseSchema
+} from '@invoicetrackr/types';
+import { RouteShorthandOptionsWithHandler } from 'fastify';
+import z from 'zod/v4';
+
+import {
+  deleteExpenseAttachment,
+  getExpenseAttachment,
+  getExpenseAttachments,
+  postExpenseAttachment,
+  replaceExpenseAttachment
+} from '../controllers/expense';
+import { authMiddleware } from '../middleware/auth';
+import { preValidateFileAndFields } from '../utils/multipart';
+
+const authenticatedAccess = [authMiddleware];
+const expenseAttachmentBodySchema = z.object({ file: z.any().nullish() });
+
+export const getExpenseAttachmentsOptions: RouteShorthandOptionsWithHandler = {
+  schema: {
+    params: expenseParamsSchema,
+    response: {
+      200: getExpenseAttachmentsResponseSchema
+    }
+  },
+  preHandler: authenticatedAccess,
+  handler: getExpenseAttachments
+};
+
+export const getExpenseAttachmentOptions: RouteShorthandOptionsWithHandler = {
+  schema: {
+    params: expenseAttachmentParamsSchema,
+    response: {
+      200: getExpenseAttachmentResponseSchema
+    }
+  },
+  preHandler: authenticatedAccess,
+  handler: getExpenseAttachment
+};
+
+export const postExpenseAttachmentOptions: RouteShorthandOptionsWithHandler = {
+  schema: {
+    params: expenseParamsSchema,
+    body: expenseAttachmentBodySchema,
+    response: {
+      201: postExpenseAttachmentResponseSchema
+    }
+  },
+  preHandler: authenticatedAccess,
+  preValidation: preValidateFileAndFields,
+  handler: postExpenseAttachment
+};
+
+export const replaceExpenseAttachmentOptions: RouteShorthandOptionsWithHandler =
+  {
+    schema: {
+      params: expenseAttachmentParamsSchema,
+      body: expenseAttachmentBodySchema,
+      response: {
+        200: updateExpenseAttachmentResponseSchema
+      }
+    },
+    preHandler: authenticatedAccess,
+    preValidation: preValidateFileAndFields,
+    handler: replaceExpenseAttachment
+  };
+
+export const deleteExpenseAttachmentOptions: RouteShorthandOptionsWithHandler =
+  {
+    schema: {
+      params: expenseAttachmentParamsSchema,
+      response: {
+        200: messageResponseSchema
+      }
+    },
+    preHandler: authenticatedAccess,
+    handler: deleteExpenseAttachment
+  };

--- a/server/src/routes/expense.ts
+++ b/server/src/routes/expense.ts
@@ -1,0 +1,48 @@
+import {
+  DoneFuncWithErrOrRes,
+  FastifyInstance,
+  FastifyPluginOptions
+} from 'fastify';
+
+import {
+  deleteExpenseAttachmentOptions,
+  getExpenseAttachmentOptions,
+  getExpenseAttachmentsOptions,
+  postExpenseAttachmentOptions,
+  replaceExpenseAttachmentOptions
+} from '../options/expense';
+
+const expenseRoutes = (
+  fastify: FastifyInstance,
+  _options: FastifyPluginOptions,
+  done: DoneFuncWithErrOrRes
+) => {
+  fastify.get(
+    '/api/:userId/expenses/:expenseId/attachments',
+    getExpenseAttachmentsOptions
+  );
+
+  fastify.get(
+    '/api/:userId/expenses/:expenseId/attachments/:attachmentId',
+    getExpenseAttachmentOptions
+  );
+
+  fastify.post(
+    '/api/:userId/expenses/:expenseId/attachments',
+    postExpenseAttachmentOptions
+  );
+
+  fastify.put(
+    '/api/:userId/expenses/:expenseId/attachments/:attachmentId',
+    replaceExpenseAttachmentOptions
+  );
+
+  fastify.delete(
+    '/api/:userId/expenses/:expenseId/attachments/:attachmentId',
+    deleteExpenseAttachmentOptions
+  );
+
+  done();
+};
+
+export default expenseRoutes;

--- a/shared/types/src/expense.ts
+++ b/shared/types/src/expense.ts
@@ -1,0 +1,31 @@
+import z from 'zod/v4';
+
+export const expenseAttachmentSchema = z.object({
+  id: z.number(),
+  expenseId: z.number(),
+  storageProvider: z.string(),
+  resourceType: z.string(),
+  originalFileName: z.string(),
+  sanitizedFileName: z.string(),
+  mimeType: z.string(),
+  fileSize: z.number(),
+  checksum: z.string(),
+  malwareScanStatus: z.string(),
+  uploadedAt: z.string().nullish(),
+  updatedAt: z.string().nullish(),
+  previewUrl: z.string().optional(),
+  downloadUrl: z.string().optional()
+});
+
+export const expenseAttachmentParamsSchema = z.object({
+  userId: z.string(),
+  expenseId: z.string(),
+  attachmentId: z.string()
+});
+
+export const expenseParamsSchema = z.object({
+  userId: z.string(),
+  expenseId: z.string()
+});
+
+export type ExpenseAttachment = z.infer<typeof expenseAttachmentSchema>;

--- a/shared/types/src/index.ts
+++ b/shared/types/src/index.ts
@@ -9,3 +9,4 @@ export * from './bank-account';
 export * from './invoice';
 export * from './user';
 export * from './client';
+export * from './expense';

--- a/shared/types/src/response.ts
+++ b/shared/types/src/response.ts
@@ -11,6 +11,7 @@ import {
   publicInvoiceSchema,
   publicInvoiceSigningSchema
 } from './invoice';
+import { expenseAttachmentSchema } from './expense';
 
 // Common response schemas
 export const messageResponseSchema = z.object({
@@ -107,6 +108,22 @@ export const updateInvoiceResponseSchema = z.object({
   message: z.string()
 });
 
+export const getExpenseAttachmentsResponseSchema = z.object({
+  attachments: z.array(expenseAttachmentSchema)
+});
+
+export const getExpenseAttachmentResponseSchema = z.object({
+  attachment: expenseAttachmentSchema
+});
+
+export const postExpenseAttachmentResponseSchema = z.object({
+  attachment: expenseAttachmentSchema,
+  message: z.string()
+});
+
+export const updateExpenseAttachmentResponseSchema =
+  postExpenseAttachmentResponseSchema;
+
 export const signInvoiceResponseSchema = z.object({
   invoice: invoiceBodySchema,
   message: z.string()
@@ -195,6 +212,20 @@ export type GetClientResponse = z.infer<typeof getClientResponseSchema>;
 export type PostClientResponse = z.infer<typeof postClientResponseSchema>;
 export type UpdateClientResponse = z.infer<typeof updateClientResponseSchema>;
 export type DeleteClientResponse = MessageResponse;
+
+export type GetExpenseAttachmentsResponse = z.infer<
+  typeof getExpenseAttachmentsResponseSchema
+>;
+export type GetExpenseAttachmentResponse = z.infer<
+  typeof getExpenseAttachmentResponseSchema
+>;
+export type PostExpenseAttachmentResponse = z.infer<
+  typeof postExpenseAttachmentResponseSchema
+>;
+export type UpdateExpenseAttachmentResponse = z.infer<
+  typeof updateExpenseAttachmentResponseSchema
+>;
+export type DeleteExpenseAttachmentResponse = MessageResponse;
 
 // Aliases
 export type AddClientResponse = PostClientResponse;


### PR DESCRIPTION
### Overview

- Adds the expense document upload foundation with owner-scoped expense attachments, attachment audit events, and a migration for the expense/attachment tables.
- Adds authenticated APIs for listing, reading, uploading, replacing, and removing expense documents, with PDF/JPEG/PNG validation, a 10 MB limit, sanitized filenames, SHA-256 checksums, and signed Cloudinary preview/download URLs.
- Adds shared schemas/types and a client API wrapper for the future expense UI.
- Updates the homepage badge to point at expense document uploads and improves the Lithuanian hero subtitle.

This intentionally does not implement the full expense CRUD/UI from REK-114; it provides the storage/API foundation for that follow-up. Locale JSON, migration journal JSON, and diff whitespace checks were run.