### PR TITLE
[REK-118]: Expense Server Unit Tests

### DIFF
--- a/server/src/controllers/__tests__/expense.ts
+++ b/server/src/controllers/__tests__/expense.ts
@@ -1,0 +1,258 @@
+import { DEFAULT_CURRENCY, ExpenseInput } from '@invoicetrackr/types';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as expenseDb from '../../database/expense';
+import { createTestApp, mockAuthMiddleware } from '../../test/app';
+import {
+  postExpenseOptions,
+  updateExpenseOptions
+} from '../../options/expense';
+import { SelectExpense } from '../../database/schema';
+
+vi.mock('../../database/expense');
+
+const testUserId = 1;
+const testExpenseId = 10;
+
+const buildExpensePayload = (
+  overrides: Partial<ExpenseInput> = {}
+): ExpenseInput => ({
+  expenseDate: '2026-07-08',
+  paymentDate: '',
+  supplier: ' Supplier UAB ',
+  documentNumber: ' EXP-1 ',
+  description: ' Accounting software ',
+  category: 'software',
+  currency: DEFAULT_CURRENCY,
+  totalAmount: '100.00',
+  eurAmount: '100.00',
+  vatAmount: '21.00',
+  businessUsePercentage: '50',
+  paymentMethod: 'card',
+  notes: ' Paid by company card ',
+  ...overrides
+});
+
+const buildExpenseFromDb = (
+  overrides: Partial<SelectExpense> = {}
+): SelectExpense => ({
+  id: testExpenseId,
+  userId: testUserId,
+  expenseDate: '2026-07-08',
+  paymentDate: null,
+  supplier: 'Supplier UAB',
+  documentNumber: 'EXP-1',
+  description: 'Accounting software',
+  category: 'software',
+  currency: DEFAULT_CURRENCY,
+  totalAmount: '100.00',
+  eurAmount: '100.00',
+  vatAmount: '21.00',
+  businessUsePercentage: '50.00',
+  deductibleAmount: '50.00',
+  paymentMethod: 'card',
+  notes: 'Paid by company card',
+  deletedAt: null,
+  createdAt: '2026-07-08T00:00:00.000Z',
+  updatedAt: '2026-07-08T00:00:00.000Z',
+  ...overrides
+});
+
+const createExpenseWriteApp = () =>
+  createTestApp((fastifyApp) => {
+    fastifyApp.post('/api/:userId/expenses', {
+      ...postExpenseOptions,
+      preHandler: mockAuthMiddleware
+    });
+    fastifyApp.put('/api/:userId/expenses/:expenseId', {
+      ...updateExpenseOptions,
+      preHandler: mockAuthMiddleware
+    });
+  });
+
+const mockInsertExpense = () => {
+  vi.mocked(expenseDb.insertExpenseInDb).mockImplementation(async (expense) =>
+    buildExpenseFromDb({ ...expense, id: testExpenseId })
+  );
+};
+
+const mockUpdateExpense = () => {
+  vi.mocked(expenseDb.updateExpenseInDb).mockImplementation(
+    async ({ userId, expenseId, expense }) =>
+      buildExpenseFromDb({ ...expense, id: expenseId, userId })
+  );
+};
+
+describe('Expense Controller', () => {
+  describe('POST /api/:userId/expenses', () => {
+    it('creates an expense with normalized totals and computed deductible amount', async () => {
+      mockInsertExpense();
+      const app = await createExpenseWriteApp();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/${testUserId}/expenses`,
+        payload: buildExpensePayload({
+          totalAmount: '123.4',
+          eurAmount: undefined,
+          vatAmount: '23.4',
+          businessUsePercentage: '33.33'
+        })
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(expenseDb.insertExpenseInDb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: testUserId,
+          totalAmount: '123.40',
+          eurAmount: '123.40',
+          vatAmount: '23.40',
+          businessUsePercentage: '33.33',
+          deductibleAmount: '41.13'
+        })
+      );
+      expect(JSON.parse(response.body).expense.deductibleAmount).toBe('41.13');
+
+      await app.close();
+    });
+
+    it('ignores client-supplied deductibleAmount and stores the server-computed value', async () => {
+      mockInsertExpense();
+      const app = await createExpenseWriteApp();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/${testUserId}/expenses`,
+        payload: {
+          ...buildExpensePayload({
+            totalAmount: '80.00',
+            businessUsePercentage: '25'
+          }),
+          deductibleAmount: '9999.99'
+        }
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(expenseDb.insertExpenseInDb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          totalAmount: '80.00',
+          businessUsePercentage: '25.00',
+          deductibleAmount: '20.00'
+        })
+      );
+
+      await app.close();
+    });
+  });
+
+  describe('PUT /api/:userId/expenses/:expenseId', () => {
+    it('recomputes deductible amount when total or business-use percentage changes', async () => {
+      mockUpdateExpense();
+      const app = await createExpenseWriteApp();
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/${testUserId}/expenses/${testExpenseId}`,
+        payload: buildExpensePayload({
+          id: testExpenseId,
+          totalAmount: '250.00',
+          businessUsePercentage: '40'
+        })
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(expenseDb.updateExpenseInDb).toHaveBeenCalledWith({
+        userId: testUserId,
+        expenseId: testExpenseId,
+        expense: expect.objectContaining({
+          totalAmount: '250.00',
+          businessUsePercentage: '40.00',
+          deductibleAmount: '100.00'
+        })
+      });
+
+      await app.close();
+    });
+
+    it('ignores client-supplied deductibleAmount and stores the recomputed value', async () => {
+      mockUpdateExpense();
+      const app = await createExpenseWriteApp();
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/${testUserId}/expenses/${testExpenseId}`,
+        payload: {
+          ...buildExpensePayload({
+            id: testExpenseId,
+            totalAmount: '0.01',
+            businessUsePercentage: '50'
+          }),
+          deductibleAmount: '0.00'
+        }
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(expenseDb.updateExpenseInDb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expense: expect.objectContaining({
+            totalAmount: '0.01',
+            businessUsePercentage: '50.00',
+            deductibleAmount: '0.01'
+          })
+        })
+      );
+
+      await app.close();
+    });
+  });
+
+  describe('schema validation', () => {
+    const invalidExpenseOverrides: Array<[string, Partial<ExpenseInput>]> = [
+      ['negative totalAmount', { totalAmount: '-1.00' }],
+      ['negative vatAmount', { vatAmount: '-1.00' }],
+      ['negative businessUsePercentage', { businessUsePercentage: '-1' }],
+      ['businessUsePercentage above 100', { businessUsePercentage: '100.01' }],
+      ['totalAmount with more than two decimals', { totalAmount: '1.001' }],
+      ['eurAmount with more than two decimals', { eurAmount: '1.001' }],
+      ['vatAmount with more than two decimals', { vatAmount: '1.001' }]
+    ];
+
+    it.each(invalidExpenseOverrides)(
+      'returns 400 for %s on create',
+      async (_label, overrides) => {
+        const app = await createExpenseWriteApp();
+
+        const response = await app.inject({
+          method: 'POST',
+          url: `/api/${testUserId}/expenses`,
+          payload: buildExpensePayload(overrides)
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(expenseDb.insertExpenseInDb).not.toHaveBeenCalled();
+        expect(expenseDb.updateExpenseInDb).not.toHaveBeenCalled();
+
+        await app.close();
+      }
+    );
+
+    it.each(invalidExpenseOverrides)(
+      'returns 400 for %s on update',
+      async (_label, overrides) => {
+        const app = await createExpenseWriteApp();
+
+        const response = await app.inject({
+          method: 'PUT',
+          url: `/api/${testUserId}/expenses/${testExpenseId}`,
+          payload: buildExpensePayload({ id: testExpenseId, ...overrides })
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(expenseDb.insertExpenseInDb).not.toHaveBeenCalled();
+        expect(expenseDb.updateExpenseInDb).not.toHaveBeenCalled();
+
+        await app.close();
+      }
+    );
+  });
+});

--- a/server/src/controllers/expense.ts
+++ b/server/src/controllers/expense.ts
@@ -1,8 +1,4 @@
-import {
-  DEFAULT_CURRENCY,
-  ExpenseBody,
-  ExpenseInput
-} from '@invoicetrackr/types';
+import { ExpenseBody, ExpenseInput } from '@invoicetrackr/types';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { UploadApiResponse, v2 as cloudinary } from 'cloudinary';
 import { MultipartFile } from '@fastify/multipart';
@@ -25,6 +21,7 @@ import {
   replaceExpenseAttachmentInDb,
   updateExpenseInDb
 } from '../database/expense';
+import { normalizeExpenseForDb } from '../utils/expense';
 
 const allowedMimeTypes = new Set([
   'application/pdf',
@@ -47,84 +44,6 @@ const sanitizeFileName = (fileName: string) => {
 
 const getChecksum = (buffer: Buffer) =>
   crypto.createHash('sha256').update(buffer).digest('hex');
-
-const parseDecimalToMinorUnits = (value: string, scale: number) => {
-  const [wholePart, decimalPart = ''] = value.split('.');
-  const normalizedDecimal = decimalPart.padEnd(scale, '0');
-
-  return (
-    BigInt(wholePart) * BigInt(10 ** scale) + BigInt(normalizedDecimal || '0')
-  );
-};
-
-const formatMinorUnits = (value: bigint, scale: number) => {
-  const factor = BigInt(10 ** scale);
-  const wholePart = value / factor;
-  const decimalPart = (value % factor).toString().padStart(scale, '0');
-
-  return `${wholePart}.${decimalPart}`;
-};
-
-const calculateDeductibleAmount = (
-  totalAmount: string,
-  businessUsePercentage: ExpenseInput['businessUsePercentage']
-) => {
-  const totalCents = parseDecimalToMinorUnits(totalAmount, 2);
-  const businessUseBasisPoints = parseDecimalToMinorUnits(
-    String(businessUsePercentage),
-    2
-  );
-  const deductibleCents =
-    (totalCents * businessUseBasisPoints + 5000n) / 10000n;
-
-  return formatMinorUnits(deductibleCents, 2);
-};
-
-const normalizeOptionalText = (value?: string | null) => {
-  const normalizedValue = value?.trim();
-
-  return normalizedValue || null;
-};
-
-const normalizeOptionalMoney = (value?: string | null) =>
-  value && value.trim()
-    ? formatMinorUnits(parseDecimalToMinorUnits(value, 2), 2)
-    : null;
-
-const normalizeExpenseForDb = (expense: ExpenseInput) => {
-  const totalAmount = formatMinorUnits(
-    parseDecimalToMinorUnits(expense.totalAmount, 2),
-    2
-  );
-  const eurAmount = formatMinorUnits(
-    parseDecimalToMinorUnits(expense.eurAmount || totalAmount, 2),
-    2
-  );
-  const businessUsePercentage = formatMinorUnits(
-    parseDecimalToMinorUnits(String(expense.businessUsePercentage ?? 100), 2),
-    2
-  );
-
-  return {
-    expenseDate: expense.expenseDate,
-    paymentDate: normalizeOptionalText(expense.paymentDate),
-    supplier: expense.supplier.trim(),
-    documentNumber: normalizeOptionalText(expense.documentNumber),
-    description: expense.description.trim(),
-    category: expense.category,
-    currency: expense.currency ?? DEFAULT_CURRENCY,
-    totalAmount,
-    eurAmount,
-    vatAmount: normalizeOptionalMoney(expense.vatAmount),
-    businessUsePercentage,
-    deductibleAmount: calculateDeductibleAmount(
-      totalAmount,
-      businessUsePercentage
-    ),
-    paymentMethod: expense.paymentMethod || null,
-    notes: normalizeOptionalText(expense.notes)
-  };
-};
 
 const mapExpenseForResponse = (
   expense: SelectExpense,

--- a/server/src/utils/__tests__/expense.ts
+++ b/server/src/utils/__tests__/expense.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { calculateDeductibleAmount, normalizeExpenseForDb } from '../expense';
+
+describe('expense utilities', () => {
+  describe('calculateDeductibleAmount', () => {
+    it.each([
+      ['0.00', '75', '0.00'],
+      ['100.00', '100', '100.00'],
+      ['100.00', '50', '50.00'],
+      ['10.00', '33.33', '3.33'],
+      ['0.01', '50', '0.01']
+    ])(
+      'calculates %s at %s percent as %s',
+      (totalAmount, businessUsePercentage, expected) => {
+        expect(
+          calculateDeductibleAmount(totalAmount, businessUsePercentage)
+        ).toBe(expected);
+      }
+    );
+  });
+
+  describe('normalizeExpenseForDb', () => {
+    it('normalizes monetary fields and business-use percentage', () => {
+      expect(
+        normalizeExpenseForDb({
+          expenseDate: '2026-07-08',
+          paymentDate: '',
+          supplier: ' Test Supplier ',
+          documentNumber: ' DOC-1 ',
+          description: ' Business software ',
+          category: 'software',
+          totalAmount: '10',
+          eurAmount: '9.5',
+          vatAmount: '1',
+          businessUsePercentage: 33.3,
+          paymentMethod: 'card',
+          notes: ' Notes '
+        })
+      ).toMatchObject({
+        supplier: 'Test Supplier',
+        documentNumber: 'DOC-1',
+        description: 'Business software',
+        totalAmount: '10.00',
+        eurAmount: '9.50',
+        vatAmount: '1.00',
+        businessUsePercentage: '33.30',
+        deductibleAmount: '3.33',
+        notes: 'Notes'
+      });
+    });
+
+    it('defaults currency and eurAmount while calculating deductible amount from totalAmount', () => {
+      expect(
+        normalizeExpenseForDb({
+          expenseDate: '2026-07-08',
+          supplier: 'Fuel',
+          description: 'Client trip',
+          category: 'transport',
+          totalAmount: '12.00',
+          vatAmount: '2.52',
+          businessUsePercentage: '25'
+        })
+      ).toMatchObject({
+        currency: 'eur',
+        totalAmount: '12.00',
+        eurAmount: '12.00',
+        vatAmount: '2.52',
+        businessUsePercentage: '25.00',
+        deductibleAmount: '3.00'
+      });
+    });
+
+    it('does not include VAT amount in the deductible calculation', () => {
+      const withoutVat = normalizeExpenseForDb({
+        expenseDate: '2026-07-08',
+        supplier: 'Software',
+        description: 'Subscription',
+        category: 'software',
+        totalAmount: '100.00',
+        vatAmount: null,
+        businessUsePercentage: '60'
+      });
+      const withVat = normalizeExpenseForDb({
+        expenseDate: '2026-07-08',
+        supplier: 'Software',
+        description: 'Subscription',
+        category: 'software',
+        totalAmount: '100.00',
+        vatAmount: '21.00',
+        businessUsePercentage: '60'
+      });
+
+      expect(withVat.deductibleAmount).toBe(withoutVat.deductibleAmount);
+      expect(withVat.deductibleAmount).toBe('60.00');
+    });
+  });
+});

--- a/server/src/utils/expense.ts
+++ b/server/src/utils/expense.ts
@@ -1,0 +1,79 @@
+import { DEFAULT_CURRENCY, ExpenseInput } from '@invoicetrackr/types';
+
+const parseDecimalToMinorUnits = (value: string, scale: number) => {
+  const [wholePart, decimalPart = ''] = value.split('.');
+  const normalizedDecimal = decimalPart.padEnd(scale, '0');
+
+  return (
+    BigInt(wholePart) * BigInt(10 ** scale) + BigInt(normalizedDecimal || '0')
+  );
+};
+
+const formatMinorUnits = (value: bigint, scale: number) => {
+  const factor = BigInt(10 ** scale);
+  const wholePart = value / factor;
+  const decimalPart = (value % factor).toString().padStart(scale, '0');
+
+  return `${wholePart}.${decimalPart}`;
+};
+
+export const calculateDeductibleAmount = (
+  totalAmount: string,
+  businessUsePercentage: ExpenseInput['businessUsePercentage']
+) => {
+  const totalCents = parseDecimalToMinorUnits(totalAmount, 2);
+  const businessUseBasisPoints = parseDecimalToMinorUnits(
+    String(businessUsePercentage),
+    2
+  );
+  const deductibleCents =
+    (totalCents * businessUseBasisPoints + 5000n) / 10000n;
+
+  return formatMinorUnits(deductibleCents, 2);
+};
+
+const normalizeOptionalText = (value?: string | null) => {
+  const normalizedValue = value?.trim();
+
+  return normalizedValue || null;
+};
+
+const normalizeOptionalMoney = (value?: string | null) =>
+  value && value.trim()
+    ? formatMinorUnits(parseDecimalToMinorUnits(value, 2), 2)
+    : null;
+
+export const normalizeExpenseForDb = (expense: ExpenseInput) => {
+  const totalAmount = formatMinorUnits(
+    parseDecimalToMinorUnits(expense.totalAmount, 2),
+    2
+  );
+  const eurAmount = formatMinorUnits(
+    parseDecimalToMinorUnits(expense.eurAmount || totalAmount, 2),
+    2
+  );
+  const businessUsePercentage = formatMinorUnits(
+    parseDecimalToMinorUnits(String(expense.businessUsePercentage ?? 100), 2),
+    2
+  );
+
+  return {
+    expenseDate: expense.expenseDate,
+    paymentDate: normalizeOptionalText(expense.paymentDate),
+    supplier: expense.supplier.trim(),
+    documentNumber: normalizeOptionalText(expense.documentNumber),
+    description: expense.description.trim(),
+    category: expense.category,
+    currency: expense.currency ?? DEFAULT_CURRENCY,
+    totalAmount,
+    eurAmount,
+    vatAmount: normalizeOptionalMoney(expense.vatAmount),
+    businessUsePercentage,
+    deductibleAmount: calculateDeductibleAmount(
+      totalAmount,
+      businessUsePercentage
+    ),
+    paymentMethod: expense.paymentMethod || null,
+    notes: normalizeOptionalText(expense.notes)
+  };
+};


### PR DESCRIPTION
### Overview
* Removed duplicated expense normalization and money-calculation helpers from `expense.ts`
* Simplified the controller by relying on shared expense formatting/normalization logic
* Reduced controller size by 83 lines while keeping upload/attachment handling intact
* Improved maintainability by centralizing amount parsing, deductible calculation, and optional field normalization
