### PR TITLE
[REK-59] Detect visitor locale and default LT for Lithuanian users

### DIFF
--- a/client/src/i18n/__tests__/resolve-locale.test.ts
+++ b/client/src/i18n/__tests__/resolve-locale.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveLocale } from '../resolve-locale';
+
+describe('resolveLocale', () => {
+  it('returns Lithuanian when the locale cookie is lt', () => {
+    expect(resolveLocale('lt', 'en-US,en;q=0.9')).toBe('lt');
+  });
+
+  it('returns English when the locale cookie is en', () => {
+    expect(resolveLocale('en', 'lt-LT,lt;q=0.9')).toBe('en');
+  });
+
+  it('gives the cookie priority over Accept-Language', () => {
+    expect(resolveLocale('en', 'lt-LT,lt;q=0.9')).toBe('en');
+    expect(resolveLocale('lt', 'en-US,en;q=0.9')).toBe('lt');
+  });
+
+  it('returns Lithuanian for a Lithuanian browser without a cookie', () => {
+    expect(resolveLocale(undefined, 'lt-LT,lt;q=0.9,en;q=0.8')).toBe('lt');
+  });
+
+  it('trims whitespace before parsing Accept-Language quality weights', () => {
+    expect(resolveLocale(undefined, 'lt; q=0.8,en; q=0.9')).toBe('en');
+  });
+
+  it('returns English for an English browser without a cookie', () => {
+    expect(resolveLocale(undefined, 'en-US,en;q=0.9')).toBe('en');
+  });
+
+  it('defaults to English for an unsupported browser language', () => {
+    expect(resolveLocale(undefined, 'de-DE,de;q=0.9')).toBe('en');
+  });
+
+  it('defaults to English when Accept-Language is missing', () => {
+    expect(resolveLocale(undefined, null)).toBe('en');
+  });
+
+  it('ignores an unsupported locale cookie', () => {
+    expect(resolveLocale('de', 'lt-LT,lt;q=0.9')).toBe('lt');
+  });
+});

--- a/client/src/i18n/request.ts
+++ b/client/src/i18n/request.ts
@@ -1,24 +1,16 @@
 import { cookies, headers } from 'next/headers';
 import { getRequestConfig } from 'next-intl/server';
 
-export default getRequestConfig(async () => {
-  let locale = 'lt';
+import { resolveLocale } from './resolve-locale';
 
+export default getRequestConfig(async () => {
   const cookieStore = await cookies();
   const localeFromCookies = cookieStore.get('locale')?.value;
 
-  if (localeFromCookies) locale = localeFromCookies;
-  else {
-    const headersList = await headers();
-    const preferredLanguage = headersList
-      .get('accept-language')
-      ?.split(',')[0]
-      ?.split(';')[0]
-      ?.substring(0, 2)
-      ?.toLowerCase();
+  const headersList = await headers();
+  const acceptLanguage = headersList.get('accept-language');
 
-    if (preferredLanguage === 'en') locale = 'en';
-  }
+  const locale = resolveLocale(localeFromCookies, acceptLanguage);
 
   return {
     locale,

--- a/client/src/i18n/resolve-locale.ts
+++ b/client/src/i18n/resolve-locale.ts
@@ -1,0 +1,42 @@
+export type SupportedLocale = 'en' | 'lt';
+
+export function resolveLocale(
+  cookieLocale?: string,
+  acceptLanguage?: string | null
+): SupportedLocale {
+  if (cookieLocale === 'en' || cookieLocale === 'lt') {
+    return cookieLocale;
+  }
+
+  if (!acceptLanguage) {
+    return 'en';
+  }
+
+  const preferredLocale = acceptLanguage
+    .split(',')
+    .map((entry, index) => {
+      const [languageTag, qualityPart] = entry.trim().split(';');
+
+      const locale = languageTag
+        ?.substring(0, 2)
+        .toLowerCase() as SupportedLocale;
+
+      const qualityParameter = qualityPart?.trim();
+      const quality = qualityParameter?.startsWith('q=')
+        ? Number.parseFloat(qualityParameter.substring(2))
+        : 1;
+
+      return {
+        locale,
+        quality: Number.isNaN(quality) ? 0 : quality,
+        index
+      };
+    })
+    .filter(
+      ({ locale, quality }) =>
+        (locale === 'en' || locale === 'lt') && quality > 0
+    )
+    .sort((a, b) => b.quality - a.quality || a.index - b.index)[0]?.locale;
+
+  return preferredLocale ?? 'en';
+}


### PR DESCRIPTION
### Overview

- Resolve the visitor locale from explicit cookie, supported Accept-Language preferences, and English fallback.
- Keep locale selection consistent with the request-level next-intl configuration.
- Add focused locale-resolution coverage, including weighted headers with optional whitespace.