### PR TITLE
[REK-98] Add focused freelancer onboarding

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -401,21 +401,36 @@
                 "tagline": "Manage invoices and track your income seamlessly"
             },
             "steps": {
-                "account": {
-                    "short_name": "Account",
-                    "name": "Create an account",
-                    "description": "Setting up your foundation"
-                },
                 "personal": {
-                    "short_name": "Profile",
-                    "name": "Freelancer Profile",
-                    "description": "Add the details needed for individual activity invoices"
+                    "short_name": "Details",
+                    "name": "Freelancer details",
+                    "description": "Add the legal details required on your individual activity invoices"
+                },
+                "banking": {
+                    "short_name": "Bank",
+                    "name": "Bank account",
+                    "description": "Optionally add the account clients should pay"
+                },
+                "defaults": {
+                    "short_name": "Defaults",
+                    "name": "Invoice defaults",
+                    "description": "Review the defaults used for new invoices"
                 }
             },
             "actions": {
                 "back": "Back",
                 "next": "Next",
-                "skip": "Skip"
+                "skip": "Skip",
+                "finish": "Finish setup"
+            },
+            "banking": {
+                "optional_note": "Bank details are optional. You can skip this step and issue invoices without payment instructions."
+            },
+            "details": {
+                "legal_name": "Legal name"
+            },
+            "defaults": {
+                "currency": "Currency"
             },
             "errors": {
                 "missing_user": "We could not find your account details. Please refresh and try again."
@@ -968,7 +983,8 @@
                 "bank_account_number_placeholder": "Enter bank account number",
                 "actions": {
                     "save": "Save",
-                    "cancel": "Cancel"
+                    "cancel": "Cancel",
+                    "skip": "Skip for now"
                 }
             }
         }

--- a/client/messages/lt.json
+++ b/client/messages/lt.json
@@ -401,21 +401,36 @@
                 "tagline": "Tvarkykite sąskaitas faktūras ir stebėkite pajamas lengvai"
             },
             "steps": {
-                "account": {
-                    "short_name": "Paskyra",
-                    "name": "Sukurti paskyrą",
-                    "description": "Kuriame pagrindą"
-                },
                 "personal": {
-                    "short_name": "Profilis",
-                    "name": "Freelancerio profilis",
-                    "description": "Įveskite duomenis, reikalingus individualios veiklos sąskaitoms"
+                    "short_name": "Duomenys",
+                    "name": "Veiklos duomenys",
+                    "description": "Įveskite teisinius duomenis, reikalingus individualios veiklos sąskaitoms"
+                },
+                "banking": {
+                    "short_name": "Bankas",
+                    "name": "Banko sąskaita",
+                    "description": "Jei norite, pridėkite sąskaitą klientų mokėjimams"
+                },
+                "defaults": {
+                    "short_name": "Nuostatos",
+                    "name": "Sąskaitų nuostatos",
+                    "description": "Peržiūrėkite naujoms sąskaitoms taikomas nuostatas"
                 }
             },
             "actions": {
                 "back": "Atgal",
                 "next": "Toliau",
-                "skip": "Praleisti"
+                "skip": "Praleisti",
+                "finish": "Baigti nustatymą"
+            },
+            "banking": {
+                "optional_note": "Banko duomenys neprivalomi. Šį žingsnį galite praleisti ir išrašyti sąskaitas be mokėjimo nurodymų."
+            },
+            "details": {
+                "legal_name": "Vardas ir pavardė"
+            },
+            "defaults": {
+                "currency": "Valiuta"
             },
             "errors": {
                 "missing_user": "Nepavyko rasti paskyros duomenų. Atnaujinkite puslapį ir bandykite dar kartą."
@@ -968,7 +983,8 @@
                 "bank_account_number_placeholder": "Pvz., LT1234 5678 9012 3456 78",
                 "actions": {
                     "save": "Išsaugoti",
-                    "cancel": "Atšaukti"
+                    "cancel": "Atšaukti",
+                    "skip": "Kol kas praleisti"
                 }
             }
         }

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -1,6 +1,7 @@
 import {
   type AccountSettingsBody,
   type AnalyticsConsentStatus,
+  CompleteOnboardingResponse,
   CreateNewPasswordResponse,
   DeleteUserAccountResponse,
   GetUserResetPasswordTokenResponse,
@@ -89,6 +90,11 @@ export const updateUser = async (
 
   return await api.put<UpdateUserResponse>(`/api/users/${id}`, userData);
 };
+
+export const completeUserOnboarding = async (userId: number) =>
+  await api.post<CompleteOnboardingResponse>(
+    `/api/users/${userId}/onboarding/complete`
+  );
 
 export const updateUserSelectedBankAccount = async (
   userId: number,

--- a/client/src/components/__tests__/multi-step-form.test.tsx
+++ b/client/src/components/__tests__/multi-step-form.test.tsx
@@ -1,32 +1,61 @@
-import { DEFAULT_CURRENCY, User } from '@invoicetrackr/types';
-import { render, screen } from '@testing-library/react';
-import { ComponentProps, JSX } from 'react';
+import { DEFAULT_CURRENCY, type User } from '@invoicetrackr/types';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { type ComponentProps, type JSX } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DASHBOARD_PAGE } from '@/lib/constants/pages';
 import { withIntl } from '@/test/with-intl';
 
 import MultiStepForm from '../multi-step-form';
 
-const mockSignUpAction = vi.fn();
-const mockPersonalInfoAction = vi.fn();
 const mockRouterPush = vi.fn();
-const mockRouterReplace = vi.fn();
 const mockRouterRefresh = vi.fn();
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockRouterPush,
-    replace: mockRouterReplace,
     refresh: mockRouterRefresh
   })
 }));
 
 vi.mock('@/lib/actions', () => ({
   signInWithGoogleAction: vi.fn(),
-  signUpAction: (...args: Array<unknown>) => mockSignUpAction(...args),
-  updateUserAction: (...args: Array<unknown>) =>
-    mockPersonalInfoAction(...args),
-  updateSessionAction: vi.fn()
+  signUpAction: vi.fn()
+}));
+
+vi.mock('../onboarding/freelancer-details-step', () => ({
+  default: ({ onSuccess }: { onSuccess: () => void }) => (
+    <button type="button" onClick={onSuccess}>
+      Save freelancer details
+    </button>
+  )
+}));
+
+vi.mock('../onboarding/invoice-defaults-step', () => ({
+  default: ({ onSuccess }: { onSuccess: () => void }) => (
+    <button type="button" onClick={onSuccess}>
+      Finish setup
+    </button>
+  )
+}));
+
+vi.mock('../profile/bank-account-form', () => ({
+  default: ({
+    onSkip,
+    onSuccess
+  }: {
+    onSkip: () => void;
+    onSuccess: () => void;
+  }) => (
+    <div>
+      <button type="button" onClick={onSkip}>
+        Skip for now
+      </button>
+      <button type="button" onClick={onSuccess}>
+        Add bank account
+      </button>
+    </div>
+  )
 }));
 
 describe('<MultiStepForm />', () => {
@@ -36,6 +65,7 @@ describe('<MultiStepForm />', () => {
   const existingUser: User = {
     id: 1,
     email: 'test@example.com',
+    invoiceEmail: 'invoices@example.com',
     name: 'Test User',
     businessNumber: '123456789',
     address: 'Test Address',
@@ -53,44 +83,105 @@ describe('<MultiStepForm />', () => {
   };
 
   beforeEach(() => {
-    props = {
-      existingUserData: existingUser
-    };
-    mockSignUpAction.mockClear();
-    mockPersonalInfoAction.mockClear();
-    mockRouterPush.mockClear();
-    mockRouterReplace.mockClear();
-    mockRouterRefresh.mockClear();
+    props = { existingUserData: existingUser };
   });
 
-  it('renders first step (sign up) by default', () => {
-    props.existingUserData = undefined;
+  it('renders the standalone sign-up form before authentication', () => {
+    renderHelper(<MultiStepForm />);
+
+    expect(screen.getByTestId('sign-up-form')).toBeInTheDocument();
+  });
+
+  it('restores an incomplete profile to freelancer details', () => {
+    renderHelper(
+      <MultiStepForm
+        existingUserData={{
+          ...existingUser,
+          name: '',
+          selectedBankAccountId: null
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Freelancer details' })
+    ).toBeInTheDocument();
+  });
+
+  it('restores a complete profile without banking to the optional bank step', () => {
+    renderHelper(
+      <MultiStepForm
+        existingUserData={{ ...existingUser, selectedBankAccountId: null }}
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Bank account' })
+    ).toBeInTheDocument();
+  });
+
+  it('restores a user with a selected bank account to invoice defaults', () => {
     renderHelper(<MultiStepForm {...props} />);
 
-    expect(screen.getByTestId('sign-up-form')).toBeDefined();
+    expect(
+      screen.getByRole('heading', { name: 'Invoice defaults' })
+    ).toBeInTheDocument();
   });
 
-  it('renders personal information step when user data exists without personal info', () => {
-    const userWithoutPersonalInfo: User = {
-      ...existingUser,
-      email: '',
-      name: '',
-      address: '',
-      businessNumber: ''
-    };
+  it('advances only after the freelancer step reports a persisted save', () => {
+    renderHelper(
+      <MultiStepForm
+        existingUserData={{
+          ...existingUser,
+          name: '',
+          selectedBankAccountId: null
+        }}
+      />
+    );
 
-    renderHelper(<MultiStepForm existingUserData={userWithoutPersonalInfo} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save freelancer details' })
+    );
 
     expect(
-      screen.getByRole('heading', { name: 'Freelancer Profile' })
-    ).toBeDefined();
+      screen.getByRole('heading', { name: 'Bank account' })
+    ).toBeInTheDocument();
   });
 
-  it('keeps completed users on the freelancer profile step when rendered directly', () => {
-    renderHelper(<MultiStepForm {...props} existingUserData={existingUser} />);
+  it('allows the optional bank step to be skipped', () => {
+    renderHelper(
+      <MultiStepForm
+        existingUserData={{ ...existingUser, selectedBankAccountId: null }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }));
 
     expect(
-      screen.getByRole('heading', { name: 'Freelancer Profile' })
-    ).toBeDefined();
+      screen.getByRole('heading', { name: 'Invoice defaults' })
+    ).toBeInTheDocument();
+  });
+
+  it('advances after a bank account is persisted and selected', () => {
+    renderHelper(
+      <MultiStepForm
+        existingUserData={{ ...existingUser, selectedBankAccountId: null }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add bank account' }));
+
+    expect(
+      screen.getByRole('heading', { name: 'Invoice defaults' })
+    ).toBeInTheDocument();
+  });
+
+  it('refreshes the completed session and redirects to the dashboard', () => {
+    renderHelper(<MultiStepForm {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Finish setup' }));
+
+    expect(mockRouterRefresh).toHaveBeenCalledOnce();
+    expect(mockRouterPush).toHaveBeenCalledWith(DASHBOARD_PAGE);
   });
 });

--- a/client/src/components/auth/__tests__/auth-forms.test.tsx
+++ b/client/src/components/auth/__tests__/auth-forms.test.tsx
@@ -52,7 +52,7 @@ describe('auth forms', () => {
       errors: {
         email: '',
         password: 'Password must contain at least one lowercase character',
-        confirmPassword: ''
+        confirmedPassword: ''
       }
     });
 
@@ -83,6 +83,27 @@ describe('auth forms', () => {
       )
     ).not.toBeInTheDocument();
     expect(screen.queryByText('Validation failed')).not.toBeInTheDocument();
+  });
+
+  it('renders server confirmation-password errors on the confirm password field', async () => {
+    mockSignUpAction.mockResolvedValue({
+      ok: false,
+      message: 'Validation failed',
+      errors: {
+        confirmedPassword: 'Passwords do not match.'
+      }
+    });
+
+    render(withIntl(<SignUpForm />));
+
+    await userEvent.type(screen.getByLabelText('Email'), 'user@example.com');
+    await userEvent.type(screen.getByLabelText('Password'), '12345678');
+    await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    expect(
+      await screen.findByText('Passwords do not match.')
+    ).toBeInTheDocument();
+    expect(mockSignUpAction).toHaveBeenCalledTimes(1);
   });
 
   it('keeps login values and clears the stale error when a field changes', async () => {

--- a/client/src/components/auth/create-new-password-form.tsx
+++ b/client/src/components/auth/create-new-password-form.tsx
@@ -15,7 +15,8 @@ import {
   Input,
   Label,
   Link,
-  TextField} from '@heroui/react';
+  TextField
+} from '@heroui/react';
 import { useTranslations } from 'next-intl';
 import type { FormEvent } from 'react';
 import { useState } from 'react';
@@ -132,14 +133,14 @@ export default function CreateNewPasswordForm({ userId, token }: Props) {
             {response?.message && (
               <div className="mb-6 flex items-center gap-1">
                 {response.ok ? (
-                  <CheckCircleIcon className="text-success-500 h-5 w-5" />
+                  <CheckCircleIcon className="text-success h-5 w-5" />
                 ) : (
-                  <ExclamationCircleIcon className="text-danger-500 h-5 w-5" />
+                  <ExclamationCircleIcon className="text-danger h-5 w-5" />
                 )}
                 <p
                   className={cn('text-sm', {
-                    'text-danger-500': !response.ok,
-                    'text-success-500': response.ok
+                    'text-danger': !response.ok,
+                    'text-success': response.ok
                   })}
                 >
                   {response.message}

--- a/client/src/components/auth/forgot-password-form.tsx
+++ b/client/src/components/auth/forgot-password-form.tsx
@@ -15,7 +15,8 @@ import {
   Input,
   Label,
   Link,
-  TextField} from '@heroui/react';
+  TextField
+} from '@heroui/react';
 import { useTranslations } from 'next-intl';
 import type { FormEvent } from 'react';
 import { useState } from 'react';
@@ -87,15 +88,14 @@ export default function ForgotPasswordForm() {
             {response?.message && (
               <div className="mb-6 flex items-center gap-1">
                 {response.ok ? (
-                  <CheckCircleIcon className="text-success-400 h-5 w-5" />
+                  <CheckCircleIcon className="text-success h-5 w-5" />
                 ) : (
-                  // TODO: Replace red with danger
-                  <ExclamationCircleIcon className="h-5 w-5 text-rose-500" />
+                  <ExclamationCircleIcon className="text-danger h-5 w-5" />
                 )}
                 <p
                   className={cn('text-sm', {
-                    'text-success-400': response.ok,
-                    'text-rose-500': !response.ok
+                    'text-success': response.ok,
+                    'text-danger': !response.ok
                   })}
                 >
                   {response.message}

--- a/client/src/components/auth/sign-up-form.tsx
+++ b/client/src/components/auth/sign-up-form.tsx
@@ -30,7 +30,7 @@ import { LOGIN_PAGE } from '@/lib/constants/pages';
 type SignUpFormModel = {
   email: string;
   password: string;
-  confirmPassword: string;
+  confirmedPassword: string;
 };
 
 const initialSubmissionMessage = {
@@ -57,7 +57,7 @@ export default function SignUpForm({ headerContent }: Props) {
     defaultValues: {
       email: '',
       password: '',
-      confirmPassword: ''
+      confirmedPassword: ''
     }
   });
   const [submissionMessage, setSubmissionMessage] =
@@ -77,7 +77,7 @@ export default function SignUpForm({ headerContent }: Props) {
     const formData = new FormData();
     formData.append('email', data.email);
     formData.append('password', data.password);
-    formData.append('confirm-password', data.confirmPassword);
+    formData.append('confirmedPassword', data.confirmedPassword);
 
     const response = await signUpAction(initialSubmissionMessage, formData);
     if (response?.ok === false) {
@@ -106,16 +106,16 @@ export default function SignUpForm({ headerContent }: Props) {
     if (!submissionMessage.ok) {
       return (
         <div className="mb-6 flex items-center gap-1">
-          <ExclamationCircleIcon className="text-danger-500 h-5 w-5" />
-          <p className="text-danger-500 text-sm">{submissionMessage.message}</p>
+          <ExclamationCircleIcon className="text-danger h-5 w-5" />
+          <p className="text-danger text-sm">{submissionMessage.message}</p>
         </div>
       );
     }
 
     return (
       <div className="mb-6 flex items-center gap-1">
-        <CheckCircleIcon className="text-success-500 h-5 w-5" />
-        <p className="text-success-500 text-sm">{submissionMessage.message}</p>
+        <CheckCircleIcon className="text-success h-5 w-5" />
+        <p className="text-success text-sm">{submissionMessage.message}</p>
       </div>
     );
   };
@@ -179,17 +179,20 @@ export default function SignUpForm({ headerContent }: Props) {
             />
             <FieldError>{errors.password?.message}</FieldError>
           </TextField>
-          <TextField variant="secondary" isInvalid={!!errors.confirmPassword}>
+          <TextField
+            variant="secondary"
+            isInvalid={!!errors.confirmedPassword}
+          >
             <Label>{t('confirm_password')}</Label>
             <Input
-              {...register('confirmPassword', {
-                onChange: () => clearFieldState('confirmPassword')
+              {...register('confirmedPassword', {
+                onChange: () => clearFieldState('confirmedPassword')
               })}
               id="confirm-password"
               type="password"
               placeholder={t('confirm_password_placeholder')}
             />
-            <FieldError>{errors.confirmPassword?.message}</FieldError>
+            <FieldError>{errors.confirmedPassword?.message}</FieldError>
           </TextField>
           <Button
             className="w-full justify-between"

--- a/client/src/components/auth/verify-email-result-card.tsx
+++ b/client/src/components/auth/verify-email-result-card.tsx
@@ -6,7 +6,7 @@ import {
   ExclamationCircleIcon,
   ShieldCheckIcon
 } from '@heroicons/react/24/outline';
-import { buttonVariants, Card, cn,Link } from '@heroui/react';
+import { buttonVariants, Card, cn, Link } from '@heroui/react';
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -139,7 +139,7 @@ export default function VerifyEmailResultCard({
                 strokeWidth={2.25}
               />
             ) : isError ? (
-              <ExclamationCircleIcon className="text-danger-300 h-5 w-5" />
+              <ExclamationCircleIcon className="text-danger h-5 w-5" />
             ) : (
               <ShieldCheckIcon className="text-warning h-5 w-5" />
             )}

--- a/client/src/components/client-card.tsx
+++ b/client/src/components/client-card.tsx
@@ -91,9 +91,7 @@ const ClientCard = ({
         </div>
         {amount && currency && (
           <div className="flex gap-[1px] text-lg font-medium">
-            <span className="text-success-700">
-              {getCurrencySymbol(currency)}
-            </span>
+            <span className="text-success">{getCurrencySymbol(currency)}</span>
             {Number(amount).toFixed(2)}
           </div>
         )}
@@ -174,9 +172,7 @@ const ClientCard = ({
 
         {amount && currency && (
           <div className="mt-auto flex gap-[1px] self-end text-lg font-medium">
-            <span className="text-success-700">
-              {getCurrencySymbol(currency)}
-            </span>
+            <span className="text-success">{getCurrencySymbol(currency)}</span>
             {Number(amount).toFixed(2)}
           </div>
         )}

--- a/client/src/components/invoice/invoice-modal.tsx
+++ b/client/src/components/invoice/invoice-modal.tsx
@@ -13,7 +13,8 @@ import {
   ListBoxItem,
   Modal,
   Select,
-  Spinner} from '@heroui/react';
+  Spinner
+} from '@heroui/react';
 import type { InvoiceBody, InvoiceStatus } from '@invoicetrackr/types';
 import dynamic from 'next/dynamic';
 import { useTranslations } from 'next-intl';

--- a/client/src/components/invoice/invoice-table-cell.tsx
+++ b/client/src/components/invoice/invoice-table-cell.tsx
@@ -19,7 +19,8 @@ import {
   DropdownPopover,
   DropdownTrigger,
   toast,
-  Tooltip} from '@heroui/react';
+  Tooltip
+} from '@heroui/react';
 import type {
   InvoiceBody,
   InvoiceLifecycleStatus,
@@ -172,9 +173,7 @@ const InvoiceTableCell = ({
     case 'totalAmount':
       return (
         <p className="flex gap-0.5">
-          <span className="text-success-700">
-            {getCurrencySymbol(currency)}
-          </span>
+          <span className="text-success">{getCurrencySymbol(currency)}</span>
           {(Number(invoice.totalAmount) || 0).toFixed(2)}
         </p>
       );

--- a/client/src/components/layout/authenticated-shell.tsx
+++ b/client/src/components/layout/authenticated-shell.tsx
@@ -7,6 +7,7 @@ import {
 import {
   Avatar,
   Button,
+  cn,
   Dropdown,
   DropdownItem,
   DropdownMenu,
@@ -15,11 +16,15 @@ import {
   Separator
 } from '@heroui/react';
 import type { User } from '@invoicetrackr/types';
+import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 
 import { logOutAction } from '@/lib/actions';
-import { PERSONAL_INFORMATION_PAGE } from '@/lib/constants/pages';
+import {
+  ONBOARDING_PAGE,
+  PERSONAL_INFORMATION_PAGE
+} from '@/lib/constants/pages';
 
 import LanguageSwitcher from './language-switcher';
 import MobileSidebar from './mobile-sidebar';
@@ -34,7 +39,10 @@ export default function AuthenticatedShell({
   children: ReactNode;
 }) {
   const t = useTranslations('header.user');
+  const pathname = usePathname();
+  const isOnboarding = pathname === ONBOARDING_PAGE;
   const [isMobileOpen, setIsMobileOpen] = useState(false);
+  const isMobileNavigationOpen = isMobileOpen && !isOnboarding;
   const menuTriggerRef = useRef<HTMLButtonElement>(null);
   const mobileDrawerRef = useRef<HTMLElement>(null);
   const closeMobileNavigation = () => {
@@ -43,7 +51,7 @@ export default function AuthenticatedShell({
   };
 
   useEffect(() => {
-    if (!isMobileOpen) return;
+    if (!isMobileNavigationOpen) return;
 
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
@@ -76,7 +84,7 @@ export default function AuthenticatedShell({
       document.removeEventListener('keydown', handleKeyboard);
       document.body.style.overflow = previousOverflow;
     };
-  }, [isMobileOpen]);
+  }, [isMobileNavigationOpen]);
 
   const accountMenu = (
     <Dropdown>
@@ -116,29 +124,39 @@ export default function AuthenticatedShell({
 
   return (
     <div className="flex min-h-[calc(100vh-1px)] w-full">
-      <Sidebar />
-      {isMobileOpen && (
+      {!isOnboarding ? <Sidebar /> : null}
+      {isMobileNavigationOpen && (
         <MobileSidebar
           mobileDrawerRef={mobileDrawerRef}
           onClose={closeMobileNavigation}
         />
       )}
       <div className="min-w-0 flex-1">
-        <header className="border-default-200 bg-background/90 sticky top-0 z-40 flex h-16 items-center justify-between border-b px-4 backdrop-blur md:justify-end md:px-6">
-          <Button
-            ref={menuTriggerRef}
-            isIconOnly
-            variant="ghost"
-            className="md:hidden"
-            aria-label={t('a11y.open_navigation')}
-            onPress={() => setIsMobileOpen(true)}
-          >
-            <Bars3Icon className="size-5" />
-          </Button>
+        <header
+          className={cn(
+            'border-default-200 bg-background/90 sticky top-0 z-40 flex h-16 items-center border-b px-4 backdrop-blur md:justify-end md:px-6',
+            isOnboarding ? 'justify-end' : 'justify-between'
+          )}
+        >
+          {!isOnboarding ? (
+            <Button
+              ref={menuTriggerRef}
+              isIconOnly
+              variant="ghost"
+              className="md:hidden"
+              aria-label={t('a11y.open_navigation')}
+              onPress={() => setIsMobileOpen(true)}
+            >
+              <Bars3Icon className="size-5" />
+            </Button>
+          ) : null}
           <div className="flex items-center gap-2">
             <LanguageSwitcher user={user} />
             <ThemeSwitcher />
-            <Separator orientation="vertical" className="mx-1 h-6" />
+            <Separator
+              orientation="vertical"
+              className="mx-1 h-auto self-stretch"
+            />
             {accountMenu}
           </div>
         </header>

--- a/client/src/components/multi-step-form.tsx
+++ b/client/src/components/multi-step-form.tsx
@@ -1,17 +1,20 @@
 'use client';
 
 import { CheckIcon } from '@heroicons/react/24/outline';
-import { Button, cn, toast } from '@heroui/react';
+import { Button, Card, cn, Separator } from '@heroui/react';
 import { User } from '@invoicetrackr/types';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Fragment, useMemo, useState } from 'react';
+import { Fragment, useState } from 'react';
 
 import { DASHBOARD_PAGE } from '@/lib/constants/pages';
 import { isUserPersonalInformationSetUp } from '@/lib/utils/user';
 
+import AuthCardHeader from './auth/auth-card-header';
 import SignUpForm from './auth/sign-up-form';
-import PersonalInformationForm from './profile/personal-information-form';
+import FreelancerDetailsStep from './onboarding/freelancer-details-step';
+import InvoiceDefaultsStep from './onboarding/invoice-defaults-step';
+import BankAccountForm from './profile/bank-account-form';
 
 type Props = {
   existingUserData?: User;
@@ -23,39 +26,45 @@ export default function MultiStepForm({ existingUserData }: Props) {
 
   const steps = [
     {
-      id: 'account',
-      shortName: t('steps.account.short_name'),
-      name: t('steps.account.name'),
-      description: t('steps.account.description')
-    },
-    {
       id: 'personal',
       shortName: t('steps.personal.short_name'),
       name: t('steps.personal.name'),
       description: t('steps.personal.description')
+    },
+    {
+      id: 'banking',
+      shortName: t('steps.banking.short_name'),
+      name: t('steps.banking.name'),
+      description: t('steps.banking.description')
+    },
+    {
+      id: 'defaults',
+      shortName: t('steps.defaults.short_name'),
+      name: t('steps.defaults.name'),
+      description: t('steps.defaults.description')
     }
   ];
-  const initialCurrentStep = useMemo(() => {
+  const initialCurrentStep = (() => {
     if (!existingUserData) return 0;
-    if (isUserPersonalInformationSetUp(existingUserData)) return 1;
-
-    return 1;
-  }, [existingUserData]);
-  const minimumAllowedStep = existingUserData ? 1 : 0;
+    if (!isUserPersonalInformationSetUp(existingUserData)) return 0;
+    if (!existingUserData.selectedBankAccountId) return 1;
+    return 2;
+  })();
 
   const [currentStep, setCurrentStep] = useState(initialCurrentStep);
+  const [furthestStep, setFurthestStep] = useState(initialCurrentStep);
   const goToStep = (step: number) => {
-    setCurrentStep(Math.max(minimumAllowedStep, step));
+    if (step <= furthestStep) setCurrentStep(step);
   };
 
-  const completePersonalInformation = async () => {
-    if (!existingUserData?.id) {
-      toast(t('errors.missing_user'), { variant: 'danger' });
-      return;
-    }
-
+  const completeOnboarding = () => {
     router.refresh();
     router.push(DASHBOARD_PAGE);
+  };
+
+  const advanceToStep = (step: number) => {
+    setFurthestStep((current) => Math.max(current, step));
+    setCurrentStep(step);
   };
 
   const renderStepHeader = () => (
@@ -65,16 +74,36 @@ export default function MultiStepForm({ existingUserData }: Props) {
   const renderStep = () => {
     switch (currentStep) {
       case 0:
-        return <SignUpForm headerContent={renderStepHeader()} />;
+        return (
+          <FreelancerDetailsStep
+            user={existingUserData!}
+            onSuccess={() => advanceToStep(1)}
+          />
+        );
       case 1:
         return (
-          <PersonalInformationForm
-            cardHeaderTitle={steps[1].name}
-            cardHeaderDescription={steps[1].description}
-            defaultValues={existingUserData}
-            headerContent={renderStepHeader()}
-            hideEmailVerificationBanner
-            onSuccess={completePersonalInformation}
+          <Card.Content className="p-6">
+            <p className="text-muted mb-4 text-sm">
+              {t('banking.optional_note')}
+            </p>
+            <BankAccountForm
+              variant="inline"
+              userId={existingUserData?.id}
+              userSelectedBankAccountId={
+                existingUserData?.selectedBankAccountId
+              }
+              isUserOnboarding
+              shouldSelectOnCreate
+              onSkip={() => advanceToStep(2)}
+              onSuccess={() => advanceToStep(2)}
+            />
+          </Card.Content>
+        );
+      case 2:
+        return (
+          <InvoiceDefaultsStep
+            user={existingUserData!}
+            onSuccess={completeOnboarding}
           />
         );
       default:
@@ -85,7 +114,7 @@ export default function MultiStepForm({ existingUserData }: Props) {
   const renderHorizontalStepper = () => (
     <div className="flex w-full items-center">
       {steps.map((step, index) => {
-        const isCompleted = index < currentStep;
+        const isCompleted = index < furthestStep;
         const isCurrent = index === currentStep;
 
         return (
@@ -96,10 +125,10 @@ export default function MultiStepForm({ existingUserData }: Props) {
                 isIconOnly
                 size="sm"
                 variant={isCurrent ? 'primary' : 'outline'}
-                isDisabled={!isCurrent}
+                isDisabled={index > furthestStep}
                 onPress={() => goToStep(index)}
                 className={cn('h-8 min-w-8 text-xs font-medium', {
-                  'opacity-55': !isCurrent
+                  'opacity-55': index > furthestStep
                 })}
               >
                 {isCompleted ? <CheckIcon className="h-4 w-4" /> : index + 1}
@@ -133,7 +162,7 @@ export default function MultiStepForm({ existingUserData }: Props) {
     return (
       <section className="flex flex-1 items-center justify-center">
         <div className="w-full max-w-lg">
-          <SignUpForm headerContent={renderHorizontalStepper()} />
+          <SignUpForm />
         </div>
       </section>
     );
@@ -141,7 +170,16 @@ export default function MultiStepForm({ existingUserData }: Props) {
 
   return (
     <section className="flex flex-1 items-center justify-center py-2 md:py-6">
-      <div className="w-full max-w-lg">{renderStep()}</div>
+      <Card className="w-full max-w-xl border">
+        <AuthCardHeader
+          title={steps[currentStep].name}
+          description={steps[currentStep].description}
+        >
+          {renderStepHeader()}
+        </AuthCardHeader>
+        <Separator />
+        {renderStep()}
+      </Card>
     </section>
   );
 }

--- a/client/src/components/onboarding/freelancer-details-step.tsx
+++ b/client/src/components/onboarding/freelancer-details-step.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import {
+  Button,
+  Card,
+  FieldError,
+  Input,
+  Label,
+  TextField,
+  toast
+} from '@heroui/react';
+import type { User } from '@invoicetrackr/types';
+import { useTranslations } from 'next-intl';
+import { Controller, type SubmitHandler, useForm } from 'react-hook-form';
+
+import { updateUserAction } from '@/lib/actions/user';
+
+type FreelancerDetails = Pick<
+  User,
+  'name' | 'businessNumber' | 'address' | 'invoiceEmail' | 'phone'
+>;
+
+type Props = {
+  user: User;
+  onSuccess: () => void;
+};
+
+export default function FreelancerDetailsStep({ user, onSuccess }: Props) {
+  const t = useTranslations('profile.personal_information.form');
+  const onboardingT = useTranslations('sign_up.multi_step');
+  const {
+    control,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting }
+  } = useForm<FreelancerDetails>({
+    defaultValues: {
+      name: user.name,
+      businessNumber: user.businessNumber,
+      address: user.address,
+      invoiceEmail: user.invoiceEmail || user.email,
+      phone: user.phone || ''
+    }
+  });
+
+  const onSubmit: SubmitHandler<FreelancerDetails> = async (details) => {
+    const response = await updateUserAction({
+      user: {
+        ...user,
+        ...details,
+        businessType: 'individual'
+      },
+      signature: user.signature
+    });
+
+    if (!response.ok) {
+      toast(response.message, { variant: 'danger' });
+      Object.entries(response.validationErrors || {}).forEach(
+        ([field, message]) => {
+          setError(field as keyof FreelancerDetails, { message });
+        }
+      );
+      return;
+    }
+
+    toast(response.message, { variant: 'success' });
+    onSuccess();
+  };
+
+  const renderField = ({
+    name,
+    label,
+    placeholder
+  }: {
+    name: keyof FreelancerDetails;
+    label: string;
+    placeholder: string;
+  }) => (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <TextField variant="secondary" isInvalid={Boolean(errors[name])}>
+          <Label>{label}</Label>
+          <Input
+            name={field.name}
+            value={String(field.value || '')}
+            placeholder={placeholder}
+            onBlur={field.onBlur}
+            onChange={field.onChange}
+          />
+          {errors[name]?.message ? (
+            <FieldError>{errors[name]?.message}</FieldError>
+          ) : null}
+        </TextField>
+      )}
+    />
+  );
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Card.Content className="grid grid-cols-1 gap-4 p-6 sm:grid-cols-2">
+        {renderField({
+          name: 'name',
+          label: onboardingT('details.legal_name'),
+          placeholder: t('name_placeholder')
+        })}
+        {renderField({
+          name: 'businessNumber',
+          label: t('business_number'),
+          placeholder: t('business_number_placeholder')
+        })}
+        {renderField({
+          name: 'invoiceEmail',
+          label: t('invoice_email'),
+          placeholder: t('email_placeholder')
+        })}
+        {renderField({
+          name: 'phone',
+          label: t('phone'),
+          placeholder: t('phone_placeholder')
+        })}
+        <div className="sm:col-span-2">
+          {renderField({
+            name: 'address',
+            label: t('address'),
+            placeholder: t('address_placeholder')
+          })}
+        </div>
+      </Card.Content>
+      <Card.Footer className="justify-end px-6 py-4">
+        <Button
+          type="submit"
+          isPending={isSubmitting}
+          className="w-full sm:w-auto"
+        >
+          {onboardingT('actions.next')}
+        </Button>
+      </Card.Footer>
+    </form>
+  );
+}

--- a/client/src/components/onboarding/invoice-defaults-step.tsx
+++ b/client/src/components/onboarding/invoice-defaults-step.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import {
+  Button,
+  Card,
+  FieldError,
+  Input,
+  Label,
+  ListBox,
+  ListBoxItem,
+  Select,
+  TextField,
+  toast
+} from '@heroui/react';
+import { DEFAULT_CURRENCY, type User } from '@invoicetrackr/types';
+import { useTranslations } from 'next-intl';
+import { Controller, type SubmitHandler, useForm } from 'react-hook-form';
+
+import {
+  completeUserOnboardingAction,
+  updateUserAccountSettingsAction
+} from '@/lib/actions/user';
+
+type InvoiceDefaults = Pick<
+  User,
+  'defaultInvoiceSeries' | 'defaultPaymentTermsDays'
+>;
+
+const paymentTermsOptions = [7, 14, 30] as const;
+
+type Props = {
+  user: User;
+  onSuccess: () => void;
+};
+
+export default function InvoiceDefaultsStep({ user, onSuccess }: Props) {
+  const t = useTranslations('profile.account_settings.invoice_defaults');
+  const onboardingT = useTranslations('sign_up.multi_step');
+  const {
+    control,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting }
+  } = useForm<InvoiceDefaults>({
+    defaultValues: {
+      defaultInvoiceSeries: user.defaultInvoiceSeries || 'SF',
+      defaultPaymentTermsDays: user.defaultPaymentTermsDays || 30
+    }
+  });
+
+  const onSubmit: SubmitHandler<InvoiceDefaults> = async (defaults) => {
+    if (!user.id) return;
+
+    const normalizedSeries = defaults.defaultInvoiceSeries.trim().toUpperCase();
+    const settingsResponse = await updateUserAccountSettingsAction({
+      userId: user.id,
+      language: user.language,
+      preferredInvoiceLanguage: user.preferredInvoiceLanguage || user.language,
+      isVatPayer: user.isVatPayer,
+      defaultInvoiceVatMode: user.defaultInvoiceVatMode,
+      defaultInvoiceSeries: normalizedSeries,
+      defaultPaymentTermsDays: defaults.defaultPaymentTermsDays
+    });
+
+    if (!settingsResponse.ok) {
+      toast(settingsResponse.message, { variant: 'danger' });
+      Object.entries(settingsResponse.validationErrors || {}).forEach(
+        ([field, message]) => {
+          setError(field as keyof InvoiceDefaults, { message });
+        }
+      );
+      return;
+    }
+
+    const completionResponse = await completeUserOnboardingAction({
+      userId: user.id
+    });
+
+    if (!completionResponse.ok) {
+      toast(completionResponse.message, { variant: 'danger' });
+      return;
+    }
+
+    toast(completionResponse.message, { variant: 'success' });
+    onSuccess();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Card.Content className="grid grid-cols-1 gap-4 p-6 sm:grid-cols-2">
+        <TextField variant="secondary" isDisabled>
+          <Label>{onboardingT('defaults.currency')}</Label>
+          <Input value={DEFAULT_CURRENCY.toUpperCase()} readOnly />
+        </TextField>
+        <Controller
+          control={control}
+          name="defaultInvoiceSeries"
+          render={({ field }) => (
+            <TextField
+              variant="secondary"
+              isInvalid={Boolean(errors.defaultInvoiceSeries)}
+            >
+              <Label>{t('default_series')}</Label>
+              <Input
+                {...field}
+                value={field.value || ''}
+                maxLength={8}
+                placeholder="SF"
+                onChange={(event) =>
+                  field.onChange(event.target.value.toUpperCase())
+                }
+              />
+              <FieldError>{errors.defaultInvoiceSeries?.message}</FieldError>
+            </TextField>
+          )}
+        />
+        <Controller
+          control={control}
+          name="defaultPaymentTermsDays"
+          render={({ field }) => (
+            <Select
+              variant="secondary"
+              value={String(field.value)}
+              onChange={(key) => field.onChange(Number(key))}
+              isInvalid={Boolean(errors.defaultPaymentTermsDays)}
+              className="sm:col-span-2"
+            >
+              <Label>{t('payment_terms')}</Label>
+              <Select.Trigger>
+                <Select.Value />
+                <Select.Indicator />
+              </Select.Trigger>
+              <Select.Popover>
+                <ListBox>
+                  {paymentTermsOptions.map((days) => (
+                    <ListBoxItem
+                      key={String(days)}
+                      id={String(days)}
+                      textValue={t('payment_terms_days', { days })}
+                    >
+                      {t('payment_terms_days', { days })}
+                      <ListBoxItem.Indicator />
+                    </ListBoxItem>
+                  ))}
+                </ListBox>
+              </Select.Popover>
+              <FieldError>{errors.defaultPaymentTermsDays?.message}</FieldError>
+            </Select>
+          )}
+        />
+      </Card.Content>
+      <Card.Footer className="justify-end px-6 py-4">
+        <Button
+          type="submit"
+          isPending={isSubmitting}
+          className="w-full sm:w-auto"
+        >
+          {onboardingT('actions.finish')}
+        </Button>
+      </Card.Footer>
+    </form>
+  );
+}

--- a/client/src/components/profile/bank-account-form.tsx
+++ b/client/src/components/profile/bank-account-form.tsx
@@ -30,6 +30,7 @@ type Props = {
   userSelectedBankAccountId?: number | null;
   defaultValues?: BankAccountBody;
   onCancel?: () => void;
+  onSkip?: () => void;
   onSuccess?: (_bankAccount?: BankAccountBody) => void;
   isUserOnboarding?: boolean;
   shouldSelectOnCreate?: boolean;
@@ -43,6 +44,7 @@ export default function BankAccountForm({
   userSelectedBankAccountId,
   isUserOnboarding,
   onCancel,
+  onSkip,
   shouldSelectOnCreate,
   variant = 'card'
 }: Props) {
@@ -186,6 +188,16 @@ export default function BankAccountForm({
               {t('actions.cancel')}
             </Button>
           )}
+          {isUserOnboarding && onSkip ? (
+            <Button
+              type="button"
+              variant="secondary"
+              className="w-full sm:w-auto"
+              onPress={onSkip}
+            >
+              {t('actions.skip')}
+            </Button>
+          ) : null}
           <Button
             type="submit"
             isDisabled={!isDirty}

--- a/client/src/components/profile/delete-account-modal.tsx
+++ b/client/src/components/profile/delete-account-modal.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
-import {
-  Button,
-  Modal,
-  toast
-} from '@heroui/react';
+import { Button, Modal, toast } from '@heroui/react';
 import { useTranslations } from 'next-intl';
 import { useTransition } from 'react';
 
@@ -63,16 +59,19 @@ const DeleteAccountModal = ({ userId, isOpen, onClose }: Props) => {
 
   return (
     <Modal>
-      <Modal.Backdrop isOpen={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <Modal.Backdrop
+        isOpen={isOpen}
+        onOpenChange={(open) => !open && onClose()}
+      >
         <Modal.Container>
           <Modal.Dialog>
             <Modal.CloseTrigger />
-        <Modal.Header className="flex items-end gap-2">
-          <ExclamationTriangleIcon className="text-danger-400 h-6 w-6" />
-          <Modal.Heading>{t('title')}</Modal.Heading>
-        </Modal.Header>
-        <Modal.Body>{t('description')}</Modal.Body>
-        {renderModalFooter()}
+            <Modal.Header className="flex items-end gap-2">
+              <ExclamationTriangleIcon className="text-danger h-6 w-6" />
+              <Modal.Heading>{t('title')}</Modal.Heading>
+            </Modal.Header>
+            <Modal.Body>{t('description')}</Modal.Body>
+            {renderModalFooter()}
           </Modal.Dialog>
         </Modal.Container>
       </Modal.Backdrop>

--- a/client/src/lib/actions.ts
+++ b/client/src/lib/actions.ts
@@ -101,7 +101,7 @@ export async function signUpAction(
   const rawFormData = {
     email: formData.get('email') as string,
     password: formData.get('password') as string,
-    confirmedPassword: formData.get('confirm-password') as string
+    confirmedPassword: formData.get('confirmedPassword') as string
   };
 
   const response = await registerUser(rawFormData);

--- a/client/src/lib/actions/__tests__/user.test.ts
+++ b/client/src/lib/actions/__tests__/user.test.ts
@@ -1,0 +1,116 @@
+import { DEFAULT_CURRENCY, type User } from '@invoicetrackr/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { completeUserOnboarding, updateUser } from '@/api/user';
+import { updateSessionAction } from '@/lib/actions';
+
+import { completeUserOnboardingAction, updateUserAction } from '../user';
+
+vi.mock('@/api/user', () => ({
+  completeUserOnboarding: vi.fn(),
+  updateUser: vi.fn()
+}));
+
+vi.mock('@/lib/actions', () => ({
+  updateSessionAction: vi.fn()
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn()
+}));
+
+const user: User = {
+  id: 1,
+  type: 'sender',
+  name: 'Test Freelancer',
+  businessType: 'individual',
+  businessNumber: 'IV-123',
+  address: 'Vilnius',
+  email: 'test@example.com',
+  invoiceEmail: 'invoices@example.com',
+  phone: null,
+  selectedBankAccountId: null,
+  profilePictureUrl: '',
+  currency: DEFAULT_CURRENCY,
+  language: 'en',
+  preferredInvoiceLanguage: 'en',
+  isVatPayer: false,
+  defaultInvoiceVatMode: 'no_vat',
+  defaultInvoiceSeries: 'SF',
+  defaultPaymentTermsDays: 30,
+  onboardingCompletedAt: null
+};
+
+describe('user actions', () => {
+  beforeEach(() => {
+    vi.mocked(updateSessionAction).mockResolvedValue(undefined);
+  });
+
+  it('preserves translated completion errors from the API', async () => {
+    vi.mocked(completeUserOnboarding).mockResolvedValue({
+      data: {
+        code: 'bad_request',
+        errors: [],
+        message:
+          'Prieš baigdami nustatymą įveskite individualios veiklos duomenis.'
+      }
+    } as never);
+
+    const response = await completeUserOnboardingAction({ userId: 1 });
+
+    expect(response).toEqual({
+      ok: false,
+      message:
+        'Prieš baigdami nustatymą įveskite individualios veiklos duomenis.',
+      validationErrors: {}
+    });
+    expect(updateSessionAction).not.toHaveBeenCalled();
+  });
+
+  it('updates the session only after explicit onboarding completion', async () => {
+    vi.mocked(completeUserOnboarding).mockResolvedValue({
+      data: {
+        user: { onboardingCompletedAt: '2026-07-13T10:00:00.000Z' },
+        message: 'Your freelancer workspace is ready'
+      }
+    } as never);
+
+    const response = await completeUserOnboardingAction({ userId: 1 });
+
+    expect(response.ok).toBe(true);
+    expect(updateSessionAction).toHaveBeenCalledWith({
+      newSession: {
+        isOnboarded: true,
+        onboardingCompletedAt: '2026-07-13T10:00:00.000Z'
+      }
+    });
+  });
+
+  it('does not complete onboarding during an ordinary profile edit', async () => {
+    vi.mocked(updateUser).mockResolvedValue({
+      data: {
+        user: { id: 1 },
+        message: 'User information updated successfully'
+      }
+    } as never);
+
+    const response = await updateUserAction({
+      user,
+      signature: undefined
+    });
+
+    expect(response.ok).toBe(true);
+    expect(updateSessionAction).toHaveBeenCalledWith({
+      newSession: {
+        isVatPayer: false,
+        vatNumber: null,
+        defaultInvoiceVatMode: 'no_vat'
+      }
+    });
+    expect(updateSessionAction).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        newSession: expect.objectContaining({ isOnboarded: true })
+      })
+    );
+  });
+});

--- a/client/src/lib/actions/user.ts
+++ b/client/src/lib/actions/user.ts
@@ -10,6 +10,7 @@ import { revalidatePath } from 'next/cache';
 
 import {
   changeUserPassword,
+  completeUserOnboarding,
   resendVerificationEmail,
   updateUser,
   updateUserAccountSettings,
@@ -21,6 +22,7 @@ import { updateSessionAction } from '../actions';
 import {
   ACCOUNT_SETTINGS_PAGE,
   CHANGE_PASSWORD_PAGE,
+  ONBOARDING_PAGE,
   PERSONAL_INFORMATION_PAGE
 } from '../constants/pages';
 import { ActionResponseModel } from '../types/action';
@@ -59,8 +61,6 @@ export async function updateUserAction({
 
   await updateSessionAction({
     newSession: {
-      isOnboarded: true,
-      onboardingCompletedAt: new Date().toISOString(),
       isVatPayer: user.isVatPayer,
       vatNumber: user.isVatPayer ? user.vatNumber : null,
       ...(user.isVatPayer ? {} : { defaultInvoiceVatMode: 'no_vat' })
@@ -70,6 +70,36 @@ export async function updateUserAction({
   revalidatePath(PERSONAL_INFORMATION_PAGE);
   revalidatePath(ACCOUNT_SETTINGS_PAGE);
   return { ok: true, message: response.data.message };
+}
+
+export async function completeUserOnboardingAction({
+  userId
+}: {
+  userId: number;
+}): Promise<ActionResponseModel> {
+  const response = await completeUserOnboarding(userId);
+
+  if (isResponseError(response)) {
+    return {
+      ok: false,
+      message: response.data.message,
+      validationErrors: mapValidationErrors(response.data.errors)
+    };
+  }
+
+  await updateSessionAction({
+    newSession: {
+      isOnboarded: true,
+      onboardingCompletedAt: response.data.user.onboardingCompletedAt
+    }
+  });
+
+  revalidatePath(ONBOARDING_PAGE);
+  return {
+    ok: true,
+    message: response.data.message,
+    data: response.data.user
+  };
 }
 
 export async function updateUserAccountSettingsAction({

--- a/server/drizzle/0037_rek_98_focused_onboarding.sql
+++ b/server/drizzle/0037_rek_98_focused_onboarding.sql
@@ -1,0 +1,10 @@
+UPDATE "business_profiles"
+SET "onboarding_completed_at" = NULL,
+    "updated_at" = CURRENT_TIMESTAMP
+WHERE "onboarding_completed_at" IS NOT NULL
+  AND (
+    BTRIM("legal_name") = ''
+    OR BTRIM("activity_certificate_number") = ''
+    OR BTRIM("address") = ''
+    OR BTRIM("invoice_email") = ''
+  );

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1783738800000,
       "tag": "0036_rek_95_96_freelancer_foundation",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1783900800000,
+      "tag": "0037_rek_98_focused_onboarding",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/controllers/__tests__/invoice.ts
+++ b/server/src/controllers/__tests__/invoice.ts
@@ -380,7 +380,6 @@ describe('Invoice Controller', () => {
 
       await app.close();
     });
-
   });
 
   describe('DELETE /api/:userId/invoices/:id', () => {
@@ -516,6 +515,129 @@ describe('Invoice Controller', () => {
   });
 
   describe('POST /api/:userId/invoices/:id/send-email', () => {
+    it('rejects issuing when the freelancer profile is incomplete', async () => {
+      vi.mocked(invoiceDb.getInvoiceFromDb).mockResolvedValue(
+        invoiceFromDbFactory.build({
+          id: 1,
+          lifecycleStatus: 'draft',
+          paymentMode: 'disabled',
+          bankingInformation: undefined
+        })
+      );
+      vi.mocked(userDb.getUserFromDb).mockResolvedValue(
+        userFactory.build({ id: testUserId, address: '' })
+      );
+
+      const app = await createTestApp((fastifyApp) => {
+        fastifyApp.post(
+          '/api/:userId/invoices/:id/send-email',
+          { preHandler: mockAuthMiddleware },
+          invoiceController.sendInvoiceEmail
+        );
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/${testUserId}/invoices/1/send-email`,
+        payload: {
+          recipientEmail: 'receiver@example.com',
+          subject: 'Invoice SF001',
+          includePublicLink: false
+        }
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body).message).toContain('freelancer details');
+      expect(invoiceDb.markPublicInvoiceSentInDb).not.toHaveBeenCalled();
+      expect(mockResendSend).not.toHaveBeenCalled();
+
+      await app.close();
+    });
+
+    it('rejects issuing a manual-payment draft without bank details before mutating it', async () => {
+      vi.mocked(invoiceDb.getInvoiceFromDb).mockResolvedValue(
+        invoiceFromDbFactory.build({
+          id: 1,
+          lifecycleStatus: 'draft',
+          paymentMode: 'manual',
+          bankingInformation: undefined
+        })
+      );
+      vi.mocked(userDb.getUserFromDb).mockResolvedValue(
+        userFactory.build({ id: testUserId })
+      );
+
+      const app = await createTestApp((fastifyApp) => {
+        fastifyApp.post(
+          '/api/:userId/invoices/:id/send-email',
+          { preHandler: mockAuthMiddleware },
+          invoiceController.sendInvoiceEmail
+        );
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/${testUserId}/invoices/1/send-email`,
+        payload: {
+          recipientEmail: 'receiver@example.com',
+          subject: 'Invoice SF001'
+        }
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body).message).toContain('bank details');
+      expect(invoiceDb.preparePublicInvoiceFromDb).not.toHaveBeenCalled();
+      expect(invoiceDb.markPublicInvoiceSentInDb).not.toHaveBeenCalled();
+      expect(mockResendSend).not.toHaveBeenCalled();
+
+      await app.close();
+    });
+
+    it('issues a draft without bank details when payment instructions are disabled', async () => {
+      vi.mocked(invoiceDb.getInvoiceFromDb).mockResolvedValue(
+        invoiceFromDbFactory.build({
+          id: 1,
+          lifecycleStatus: 'draft',
+          paymentMode: 'disabled',
+          bankingInformation: undefined
+        })
+      );
+      vi.mocked(userDb.getUserFromDb).mockResolvedValue(
+        userFactory.build({ id: testUserId })
+      );
+      vi.mocked(invoiceDb.markPublicInvoiceSentInDb).mockResolvedValue({
+        id: 1
+      });
+
+      const app = await createTestApp((fastifyApp) => {
+        fastifyApp.post(
+          '/api/:userId/invoices/:id/send-email',
+          { preHandler: mockAuthMiddleware },
+          invoiceController.sendInvoiceEmail
+        );
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/${testUserId}/invoices/1/send-email`,
+        payload: {
+          recipientEmail: 'receiver@example.com',
+          subject: 'Invoice SF001',
+          includePublicLink: false
+        }
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(mockResendSend).toHaveBeenCalled();
+      expect(invoiceDb.markPublicInvoiceSentInDb).toHaveBeenCalledWith({
+        userId: testUserId,
+        id: 1,
+        requestSignature: false
+      });
+
+      await app.close();
+    });
+
     it('regenerates a revoked public link before resending invoice email', async () => {
       vi.mocked(invoiceDb.getInvoiceFromDb).mockResolvedValue(
         invoiceFromDbFactory.build({
@@ -817,5 +939,4 @@ describe('Invoice Controller', () => {
       await app.close();
     });
   });
-
 });

--- a/server/src/controllers/__tests__/user.ts
+++ b/server/src/controllers/__tests__/user.ts
@@ -9,7 +9,7 @@ import {
   userFactory,
   userWithPasswordFactory
 } from '../../test/factories/user';
-import { mockResendSend } from '../../test/setup';
+import { mockResendSend, mockUseI18n } from '../../test/setup';
 import * as userController from '../user';
 
 vi.mock('../../database/user');
@@ -477,6 +477,106 @@ describe('User Controller', () => {
       const body = JSON.parse(response.body);
       expect(body.message).toBeDefined();
       expect(userDb.deleteUserFromDb).toHaveBeenCalledWith(testUserId);
+
+      await app.close();
+    });
+  });
+
+  describe('POST /api/:userId/onboarding/complete', () => {
+    it('completes onboarding when required details and defaults are valid', async () => {
+      vi.mocked(userDb.getUserFromDb).mockResolvedValue({
+        ...mockUser,
+        selectedBankAccountId: null,
+        onboardingCompletedAt: null
+      });
+      vi.mocked(userDb.completeUserOnboardingInDb).mockResolvedValue({
+        onboardingCompletedAt: '2026-07-13T10:00:00.000Z'
+      });
+
+      const app = await createTestApp((fastifyApp) => {
+        fastifyApp.post(
+          '/api/:userId/onboarding/complete',
+          { preHandler: mockAuthMiddleware },
+          userController.completeUserOnboarding
+        );
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/${testUserId}/onboarding/complete`
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body).user.onboardingCompletedAt).toBe(
+        '2026-07-13T10:00:00.000Z'
+      );
+      expect(userDb.completeUserOnboardingInDb).toHaveBeenCalledWith(
+        testUserId
+      );
+
+      await app.close();
+    });
+
+    it('rejects an incomplete freelancer profile without recording completion', async () => {
+      mockUseI18n.mockResolvedValueOnce({
+        t: (key: string) =>
+          key === 'error.user.onboardingProfileIncomplete'
+            ? 'Add your legal name, individual activity certificate number, address, and invoice email before finishing setup.'
+            : key
+      } as never);
+      vi.mocked(userDb.getUserFromDb).mockResolvedValue({
+        ...mockUser,
+        businessNumber: '',
+        onboardingCompletedAt: null
+      });
+
+      const app = await createTestApp((fastifyApp) => {
+        fastifyApp.post(
+          '/api/:userId/onboarding/complete',
+          { preHandler: mockAuthMiddleware },
+          userController.completeUserOnboarding
+        );
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/${testUserId}/onboarding/complete`,
+        headers: { 'accept-language': 'en' }
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body).message).toContain(
+        'individual activity certificate number'
+      );
+      expect(userDb.completeUserOnboardingInDb).not.toHaveBeenCalled();
+
+      await app.close();
+    });
+
+    it('allows completion without a bank account', async () => {
+      vi.mocked(userDb.getUserFromDb).mockResolvedValue({
+        ...mockUser,
+        selectedBankAccountId: null,
+        onboardingCompletedAt: null
+      });
+      vi.mocked(userDb.completeUserOnboardingInDb).mockResolvedValue({
+        onboardingCompletedAt: '2026-07-13T10:00:00.000Z'
+      });
+
+      const app = await createTestApp((fastifyApp) => {
+        fastifyApp.post(
+          '/api/:userId/onboarding/complete',
+          { preHandler: mockAuthMiddleware },
+          userController.completeUserOnboarding
+        );
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/${testUserId}/onboarding/complete`
+      });
+
+      expect(response.statusCode).toBe(200);
 
       await app.close();
     });

--- a/server/src/controllers/invoice.ts
+++ b/server/src/controllers/invoice.ts
@@ -142,6 +142,46 @@ const isInvoicePayable = (invoice: InvoiceBody) =>
   !invoice.publicInvoiceRevokedAt &&
   !isPublicInvoiceLinkExpired(invoice.publicInvoiceExpiresAt);
 
+const hasCompleteFreelancerProfile = (
+  user: NonNullable<Awaited<ReturnType<typeof getUserFromDb>>>
+) =>
+  Boolean(
+    user.name.trim() &&
+      user.businessNumber.trim() &&
+      user.address.trim() &&
+      user.invoiceEmail?.trim()
+  );
+
+const hasCompleteInvoiceBankDetails = (invoice: InvoiceFromDb) =>
+  Boolean(
+    invoice.bankingInformation?.name?.trim() &&
+      invoice.bankingInformation.code?.trim() &&
+      invoice.bankingInformation.accountNumber?.trim()
+  );
+
+const assertInvoiceCanBeIssued = ({
+  invoice,
+  user,
+  i18n
+}: {
+  invoice: InvoiceFromDb;
+  user: NonNullable<Awaited<ReturnType<typeof getUserFromDb>>>;
+  i18n: Awaited<ReturnType<typeof useI18n>>;
+}) => {
+  if ((invoice.lifecycleStatus || 'draft') !== 'draft') return;
+
+  if (!hasCompleteFreelancerProfile(user))
+    throw new BadRequestError(i18n.t('error.invoice.senderProfileIncomplete'));
+
+  if (
+    (invoice.paymentMode || 'manual') === 'manual' &&
+    !hasCompleteInvoiceBankDetails(invoice)
+  )
+    throw new BadRequestError(
+      i18n.t('error.invoice.manualPaymentDetailsIncomplete')
+    );
+};
+
 const getManualPaymentReference = (invoice: InvoiceBody) =>
   invoice.manualPaymentReference?.trim() ||
   invoice.invoiceId ||
@@ -615,6 +655,8 @@ export const sendInvoiceEmail = async (
 
   if (!user) throw new NotFoundError(i18n.t('error.user.notFound'));
   if (!invoice) throw new NotFoundError(i18n.t('error.invoice.notFound'));
+
+  assertInvoiceCanBeIssued({ invoice, user, i18n });
 
   let publicInvoiceToken =
     invoice.publicInvoiceToken || randomBytes(32).toString('hex');

--- a/server/src/controllers/user.ts
+++ b/server/src/controllers/user.ts
@@ -25,6 +25,7 @@ import {
 import { saveResetTokenToDb } from '../database/password-reset';
 import {
   changeUserPasswordInDb,
+  completeUserOnboardingInDb,
   deleteUserFromDb,
   getUserByEmailFromDb,
   getUserEmailVerificationStatusFromDb,
@@ -342,6 +343,52 @@ export const updateUser = async (
   reply.status(200).send({
     user: updatedUser,
     message: i18n.t('success.user.updated')
+  });
+};
+
+export const completeUserOnboarding = async (
+  req: FastifyRequest<{ Params: { userId: string } }>,
+  reply: FastifyReply
+) => {
+  const userId = Number(req.params.userId);
+  const i18n = await useI18n(req);
+  const user = await getUserFromDb(userId);
+
+  if (!user) throw new NotFoundError(i18n.t('error.user.notFound'));
+
+  const hasRequiredFreelancerDetails = Boolean(
+    user.name.trim() &&
+      user.businessNumber.trim() &&
+      user.address.trim() &&
+      user.invoiceEmail?.trim()
+  );
+  const hasRequiredInvoiceDefaults = Boolean(
+    user.currency === 'eur' &&
+      /^[A-Z]{2,8}$/.test(user.defaultInvoiceSeries) &&
+      [7, 14, 30].includes(user.defaultPaymentTermsDays)
+  );
+
+  if (!hasRequiredFreelancerDetails)
+    throw new BadRequestError(i18n.t('error.user.onboardingProfileIncomplete'));
+  if (!hasRequiredInvoiceDefaults)
+    throw new BadRequestError(i18n.t('error.user.onboardingDefaultsIncomplete'));
+
+  const completedUser = await completeUserOnboardingInDb(userId);
+
+  if (!completedUser?.onboardingCompletedAt)
+    throw new BadRequestError(i18n.t('error.user.unableToCompleteOnboarding'));
+
+  if (!user.onboardingCompletedAt) {
+    await captureAnalyticsEventForUser({
+      userId,
+      event: analyticsEvents.onboardingStepCompleted,
+      properties: { step: 'completed' }
+    });
+  }
+
+  reply.status(200).send({
+    user: completedUser,
+    message: i18n.t('success.user.onboardingCompleted')
   });
 };
 

--- a/server/src/database/user.ts
+++ b/server/src/database/user.ts
@@ -136,11 +136,27 @@ export const updateUserInDb = async (
       invoiceEmail: invoiceEmail || user.email,
       phone,
       signatureUrl: signature,
-      onboardingCompletedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString()
     })
     .where(eq(businessProfilesTable.userId, Number(user.id)))
     .returning({ id: businessProfilesTable.userId });
+
+  return profiles.at(0);
+};
+
+export const completeUserOnboardingInDb = async (
+  userId: number
+): Promise<{ onboardingCompletedAt: string | null } | undefined> => {
+  const profiles = await db
+    .update(businessProfilesTable)
+    .set({
+      onboardingCompletedAt: sql<string>`COALESCE(${businessProfilesTable.onboardingCompletedAt}, CURRENT_TIMESTAMP)`,
+      updatedAt: new Date().toISOString()
+    })
+    .where(eq(businessProfilesTable.userId, userId))
+    .returning({
+      onboardingCompletedAt: businessProfilesTable.onboardingCompletedAt
+    });
 
   return profiles.at(0);
 };

--- a/server/src/locales/en.ts
+++ b/server/src/locales/en.ts
@@ -190,7 +190,8 @@ export default {
       emailVerified: 'Email verified successfully',
       emailAlreadyVerified: 'Email is already verified',
       oauthLinked: 'Google account connected successfully',
-      selectedBankAccountUpdated: 'Selected bank account updated successfully'
+      selectedBankAccountUpdated: 'Selected bank account updated successfully',
+      onboardingCompleted: 'Your freelancer workspace is ready'
     },
     invoice: {
       created: 'Invoice added successfully',
@@ -258,7 +259,13 @@ export default {
       tokenAlreadyUsed: 'Token has already been used',
       unableToUploadSignature: 'Unable to upload signature',
       unableToUpdateSelectedBankAccount:
-        'Unable to update selected bank account'
+        'Unable to update selected bank account',
+      onboardingProfileIncomplete:
+        'Add your legal name, individual activity certificate number, address, and invoice email before finishing setup.',
+      onboardingDefaultsIncomplete:
+        'Review and save a valid EUR invoice series and payment term before finishing setup.',
+      unableToCompleteOnboarding:
+        'Unable to finish setup. Please review your details and try again.'
     },
     invoice: {
       notFound: 'Invoice not found',
@@ -288,7 +295,11 @@ export default {
       voidedImmutable:
         'Voided invoices cannot be changed from the status dropdown.',
       issuedImmutable:
-        'Issued invoices cannot be edited or deleted from this flow'
+        'Issued invoices cannot be edited or deleted from this flow',
+      senderProfileIncomplete:
+        'Complete your freelancer details in Settings before issuing this invoice.',
+      manualPaymentDetailsIncomplete:
+        'Add complete bank details to this invoice or disable payment instructions before issuing it.'
     },
     client: {
       notFound: 'Client not found',

--- a/server/src/locales/lt.ts
+++ b/server/src/locales/lt.ts
@@ -196,7 +196,8 @@ export default {
       emailAlreadyVerified: 'El. paštas jau patvirtintas',
       oauthLinked: 'Google paskyra prijungta sėkmingai',
       selectedBankAccountUpdated:
-        'Pagrindinė banko sąskaita atnaujinta sėkmingai'
+        'Pagrindinė banko sąskaita atnaujinta sėkmingai',
+      onboardingCompleted: 'Jūsų individualios veiklos darbo erdvė paruošta'
     },
     invoice: {
       created: 'Sąskaita faktūra pridėta sėkmingai',
@@ -264,7 +265,13 @@ export default {
       tokenAlreadyUsed: 'Raktas jau panaudotas',
       unableToUploadSignature: 'Nepavyko įkelti parašo',
       unableToUpdateSelectedBankAccount:
-        'Nepavyko atnaujinti pagrindinės banko sąskaitos'
+        'Nepavyko atnaujinti pagrindinės banko sąskaitos',
+      onboardingProfileIncomplete:
+        'Prieš baigdami nustatymą įveskite vardą ir pavardę, individualios veiklos pažymos numerį, adresą ir sąskaitų el. paštą.',
+      onboardingDefaultsIncomplete:
+        'Prieš baigdami nustatymą peržiūrėkite ir išsaugokite tinkamą EUR sąskaitų seriją bei apmokėjimo terminą.',
+      unableToCompleteOnboarding:
+        'Nepavyko užbaigti nustatymo. Patikrinkite duomenis ir bandykite dar kartą.'
     },
     invoice: {
       notFound: 'Sąskaita faktūra nerasta',
@@ -294,7 +301,11 @@ export default {
       voidedImmutable:
         'Anuliuotų sąskaitų būsenos negalima keisti iš lentelės pasirinkimo.',
       issuedImmutable:
-        'Išrašytų sąskaitų negalima redaguoti ar ištrinti šiame sraute'
+        'Išrašytų sąskaitų negalima redaguoti ar ištrinti šiame sraute',
+      senderProfileIncomplete:
+        'Prieš išrašydami sąskaitą užpildykite individualios veiklos duomenis nustatymuose.',
+      manualPaymentDetailsIncomplete:
+        'Prie sąskaitos pridėkite visus banko duomenis arba prieš ją išrašydami išjunkite mokėjimo nurodymus.'
     },
     client: {
       notFound: 'Klientas nerastas',

--- a/server/src/options/user.ts
+++ b/server/src/options/user.ts
@@ -1,5 +1,6 @@
 import {
   accountSettingsBodySchema,
+  completeOnboardingResponseSchema,
   currentPasswordSchema,
   getUserResponseSchema,
   loginPasswordSchema,
@@ -19,6 +20,7 @@ import z from 'zod/v4';
 
 import {
   changeUserPassword,
+  completeUserOnboarding,
   createNewUserPassword,
   deleteUser,
   getUser,
@@ -107,6 +109,16 @@ export const updateUserOptions: RouteShorthandOptionsWithHandler = {
   preValidation: preValidateFileAndFields,
   preHandler: authMiddleware,
   handler: updateUser
+};
+
+export const completeUserOnboardingOptions: RouteShorthandOptionsWithHandler = {
+  schema: {
+    response: {
+      200: completeOnboardingResponseSchema
+    }
+  },
+  preHandler: authMiddleware,
+  handler: completeUserOnboarding
 };
 
 export const deleteUserOptions: RouteShorthandOptionsWithHandler = {

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   changeUserPasswordOptions,
+  completeUserOnboardingOptions,
   createNewUserPasswordOptions,
   deleteUserOptions,
   getUserOptions,
@@ -37,6 +38,11 @@ const userRoutes = (
   fastify.post('/api/users/oauth/google', postOAuthUserOptions);
 
   fastify.put('/api/users/:userId', updateUserOptions);
+
+  fastify.post(
+    '/api/users/:userId/onboarding/complete',
+    completeUserOnboardingOptions
+  );
 
   fastify.delete('/api/users/:userId', deleteUserOptions);
 

--- a/shared/types/src/response.ts
+++ b/shared/types/src/response.ts
@@ -1,5 +1,6 @@
 import z from 'zod/v4';
 import {
+  onboardingCompletionSchema,
   resetPasswordTokenGetSchema,
   userBodySchema,
   verifyEmailResponseSchema
@@ -42,6 +43,11 @@ export const verifyEmailTokenResponseSchema = verifyEmailResponseSchema;
 
 export const updateUserResponseSchema = z.object({
   user: userBodySchema.pick({ id: true }),
+  message: z.string()
+});
+
+export const completeOnboardingResponseSchema = z.object({
+  user: onboardingCompletionSchema,
   message: z.string()
 });
 
@@ -194,6 +200,9 @@ export type MessageResponse = z.infer<typeof messageResponseSchema>;
 export type GetUserResponse = z.infer<typeof getUserResponseSchema>;
 export type RegisterUserResponse = z.infer<typeof registerUserResponseSchema>;
 export type UpdateUserResponse = z.infer<typeof updateUserResponseSchema>;
+export type CompleteOnboardingResponse = z.infer<
+  typeof completeOnboardingResponseSchema
+>;
 export type LoginUserResponse = z.infer<typeof loginUserResponseSchema>;
 export type OAuthUserResponse = z.infer<typeof oauthUserResponseSchema>;
 export type UpdateUserAccountSettingsResponse = MessageResponse;

--- a/shared/types/src/user.ts
+++ b/shared/types/src/user.ts
@@ -124,6 +124,10 @@ export const accountSettingsBodySchema = userBodyBaseSchema
     language: z.string().max(2).min(2)
   });
 
+export const onboardingCompletionSchema = z.object({
+  onboardingCompletedAt: z.string()
+});
+
 // Types
 export type UserBody = z.infer<typeof userBodySchema>;
 export type User = UserBody;
@@ -135,3 +139,4 @@ export type ResetPasswordTokenGet = z.infer<typeof resetPasswordTokenGetSchema>;
 export type ResetPasswordToken = ResetPasswordTokenGet;
 export type VerifyEmailResponse = z.infer<typeof verifyEmailResponseSchema>;
 export type OAuthUserBody = z.infer<typeof oauthUserBodySchema>;
+export type OnboardingCompletion = z.infer<typeof onboardingCompletionSchema>;


### PR DESCRIPTION
### Overview

Implements REK-98 with a focused, resumable freelancer onboarding flow.

- Replace the broad onboarding screen with freelancer details, optional banking, and invoice-default steps.
- Add explicit authenticated onboarding completion and reopen migrated profiles only when required identity details are missing.
- Guard invoice issuance against incomplete freelancer profiles and missing manual-payment bank details without mutating drafts.

### Additional changes

- Align signup confirmation fields with the backend validation key so missing confirmation errors render inline, with regression coverage.
- Hide sidebar and mobile navigation during onboarding and make the user-header separator span its full height.
- Replace remaining ad hoc danger/success color utilities across auth, client, and invoice surfaces with semantic HeroUI tokens.