### PR TITLE
[REK-101] Harden invoice editor

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -596,6 +596,8 @@
             "business_number_individual": "Sole proprietorship certificate No.:",
             "address_label": "Address:",
             "invoice_date_label": "Invoice date:",
+            "service_date_label": "Service date:",
+            "notes_label": "Notes",
             "payer_label": "Payer:",
             "vat_number_label": "VAT Number:",
             "position_label": "Pos",
@@ -1205,6 +1207,8 @@
             "vat_total": "VAT Total",
             "grand_total": "Grand Total",
             "delete_service": "Delete service",
+            "move_service_up": "Move service up",
+            "move_service_down": "Move service down",
             "units": {
                 "service": "Service",
                 "hour": "Hour",
@@ -1258,7 +1262,9 @@
                 "invoice_id_label": "Invoice ID",
                 "invoice_series_label": "Invoice number series",
                 "date_label": "Date",
+                "service_date_label": "Service date",
                 "due_date_label": "Due Date",
+                "notes_label": "Client-visible notes",
                 "status_label": "Status",
                 "payment_mode_label": "Payment mode",
                 "manual_payment_reference_label": "Manual payment reference",
@@ -1291,7 +1297,9 @@
                 "invoice_id": "Invoice ID",
                 "invoice_series": "Invoice series",
                 "date": "Date",
+                "service_date": "Service date",
                 "due_date": "Due Date",
+                "notes": "Notes for the client",
                 "status": "Status",
                 "payment_mode": "Payment mode",
                 "manual_payment_reference": "Manual payment reference",
@@ -1319,7 +1327,8 @@
                 "receiver_vat_number": "e.g., LT100000000000",
                 "receiver_address": "e.g., Konstitucijos pr. 7, Vilnius",
                 "receiver_email": "e.g., billing@client.com",
-                "manual_payment_reference": "Defaults to the invoice number"
+                "manual_payment_reference": "Defaults to the invoice number",
+                "notes": "Optional information shown on the invoice"
             },
             "payment_settings": {
                 "title": "Payment settings",
@@ -1380,6 +1389,7 @@
             "signature_heading": "Signature",
             "banking_details": "Banking Details",
             "invoice_details": "Invoice Details",
+            "unsaved_changes": "You have unsaved invoice changes. Leave without saving?",
             "select_client": "Select Client",
             "due_date_preselection_chips": {
                 "seven_days": "7d",

--- a/client/messages/lt.json
+++ b/client/messages/lt.json
@@ -596,6 +596,8 @@
             "business_number_individual": "Individualios veiklos pažymėjimo Nr.:",
             "address_label": "Adresas:",
             "invoice_date_label": "Sąskaitos data:",
+            "service_date_label": "Paslaugos data:",
+            "notes_label": "Pastabos",
             "payer_label": "Mokėtojas:",
             "vat_number_label": "PVM mokėtojo kodas:",
             "position_label": "Eil. Nr.",
@@ -1205,6 +1207,8 @@
             "vat_total": "PVM suma",
             "grand_total": "Bendra suma",
             "delete_service": "Ištrinti paslaugą",
+            "move_service_up": "Perkelti paslaugą aukštyn",
+            "move_service_down": "Perkelti paslaugą žemyn",
             "units": {
                 "service": "Paslauga",
                 "hour": "Valanda",
@@ -1258,7 +1262,9 @@
                 "invoice_id_label": "Sąskaitos faktūros ID",
                 "invoice_series_label": "Sąskaitų numerių serija",
                 "date_label": "Data",
+                "service_date_label": "Paslaugos data",
                 "due_date_label": "Mokėjimo terminas",
+                "notes_label": "Klientui matomos pastabos",
                 "status_label": "Būsena",
                 "payment_mode_label": "Mokėjimo būdas",
                 "manual_payment_reference_label": "Rankinio mokėjimo paskirtis",
@@ -1291,7 +1297,9 @@
                 "invoice_id": "Sąskaitos faktūros ID",
                 "invoice_series": "Sąskaitos serija",
                 "date": "Data",
+                "service_date": "Paslaugos data",
                 "due_date": "Mokėjimo terminas",
+                "notes": "Pastabos klientui",
                 "status": "Būsena",
                 "payment_mode": "Mokėjimo būdas",
                 "manual_payment_reference": "Mokėjimo paskirtis",
@@ -1319,7 +1327,8 @@
                 "receiver_vat_number": "pvz., LT100000000000",
                 "receiver_address": "pvz., Konstitucijos pr. 7, Vilnius",
                 "receiver_email": "pvz., saskaitos@klientas.lt",
-                "manual_payment_reference": "Pagal nutylėjimą naudojamas sąskaitos numeris"
+                "manual_payment_reference": "Pagal nutylėjimą naudojamas sąskaitos numeris",
+                "notes": "Neprivaloma informacija, rodoma sąskaitoje"
             },
             "payment_settings": {
                 "title": "Mokėjimo nustatymai",
@@ -1380,6 +1389,7 @@
             "signature_heading": "Parašas",
             "banking_details": "Bankinė informacija",
             "invoice_details": "Sąskaitos faktūros informacija",
+            "unsaved_changes": "Turite neišsaugotų sąskaitos pakeitimų. Išeiti jų neišsaugojus?",
             "select_client": "Pasirinkti klientą",
             "due_date_preselection_chips": {
                 "seven_days": "7d",

--- a/client/src/components/invoice/__tests__/invoice-services-table.test.tsx
+++ b/client/src/components/invoice/__tests__/invoice-services-table.test.tsx
@@ -1,0 +1,107 @@
+import { DEFAULT_CURRENCY, type InvoiceBody } from '@invoicetrackr/types';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, FormProvider } from 'react-hook-form';
+import { describe, expect, it } from 'vitest';
+
+import { withIntl } from '@/test/with-intl';
+
+import InvoiceServicesTable from '../invoice-services-table';
+
+const services = [
+  {
+    description: 'Consulting',
+    unit: 'hour',
+    quantity: 1,
+    amount: 10,
+    vatRate: 0,
+    position: 0
+  },
+  {
+    description: 'Workshop',
+    unit: 'service',
+    quantity: 1,
+    amount: 20,
+    vatRate: 0,
+    position: 1
+  }
+];
+
+const Harness = ({ initialServices = services }) => {
+  const methods = useForm<InvoiceBody>({
+    defaultValues: { services: initialServices }
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <InvoiceServicesTable
+        currency={DEFAULT_CURRENCY}
+        invoiceServices={initialServices}
+      />
+    </FormProvider>
+  );
+};
+
+describe('<InvoiceServicesTable />', () => {
+  it('adds, removes, and protects the final line', async () => {
+    const user = userEvent.setup();
+    render(withIntl(<Harness initialServices={[services[0]]} />));
+
+    expect(
+      screen.getByRole('button', { name: 'Delete service' })
+    ).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'Add Service' }));
+    expect(
+      screen.getAllByRole('button', { name: 'Delete service' })
+    ).toHaveLength(2);
+
+    await user.click(
+      screen.getAllByRole('button', { name: 'Delete service' })[1]
+    );
+    expect(
+      screen.getByRole('button', { name: 'Delete service' })
+    ).toBeDisabled();
+  });
+
+  it('exposes first and last reorder states and moves line values', async () => {
+    const user = userEvent.setup();
+    render(withIntl(<Harness />));
+
+    const moveUpButtons = screen.getAllByRole('button', {
+      name: 'Move service up'
+    });
+    const moveDownButtons = screen.getAllByRole('button', {
+      name: 'Move service down'
+    });
+
+    expect(moveUpButtons[0]).toBeDisabled();
+    expect(moveDownButtons[1]).toBeDisabled();
+
+    await user.click(moveUpButtons[1]);
+
+    const descriptionInputs = screen.getAllByRole('textbox', {
+      name: 'Description'
+    });
+    expect(descriptionInputs[0]).toHaveValue('Workshop');
+    expect(descriptionInputs[1]).toHaveValue('Consulting');
+  });
+
+  it('uses cent rounding for immediate fractional totals', () => {
+    render(
+      withIntl(
+        <Harness
+          initialServices={[
+            {
+              ...services[0],
+              quantity: 1.5,
+              amount: 0.01
+            }
+          ]}
+        />
+      )
+    );
+
+    expect(screen.getAllByText(/0\.02/)).not.toHaveLength(0);
+  });
+});

--- a/client/src/components/invoice/__tests__/invoice-table.test.tsx
+++ b/client/src/components/invoice/__tests__/invoice-table.test.tsx
@@ -75,6 +75,8 @@ describe('<InvoiceTable/>', () => {
           },
           totalAmount: '100.00',
           date: '2023-01-01',
+          serviceDate: '2023-01-01',
+          notes: null,
           dueDate: '2023-01-10',
           status: 'pending',
           lifecycleStatus: 'issued',
@@ -82,6 +84,7 @@ describe('<InvoiceTable/>', () => {
           services: [
             {
               id: 5,
+              position: 0,
               amount: 100,
               unit: 'hours',
               description: 'Test Service',

--- a/client/src/components/invoice/free-invoice-form.tsx
+++ b/client/src/components/invoice/free-invoice-form.tsx
@@ -67,6 +67,8 @@ const FreeInvoiceForm = ({ language, currency }: Props) => {
       status: 'pending',
       totalAmount: '0.00',
       date: formatDate(new Date().toISOString()),
+      serviceDate: formatDate(new Date().toISOString()),
+      notes: '',
       dueDate: ''
     }
   });
@@ -434,6 +436,7 @@ const FreeInvoiceForm = ({ language, currency }: Props) => {
 
     return {
       ...getValues(),
+      serviceDate: getValues('date'),
       lifecycleStatus: getValues('invoiceId') ? 'issued' : 'draft',
       subtotalAmount: invoiceTotals.subtotalAmount,
       vatAmount: invoiceTotals.vatAmount,

--- a/client/src/components/invoice/invoice-form-preview.tsx
+++ b/client/src/components/invoice/invoice-form-preview.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { InvoiceBody } from '@invoicetrackr/types';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+
+import { Currency } from '@/lib/types/currency';
+
+import PDFDocument from '../pdf/pdf-document';
+import InvoiceModal from './invoice-modal';
+
+type Props = {
+  currency: Currency;
+  invoiceData: InvoiceBody;
+  language: string;
+  onClose: () => void;
+};
+
+export default function InvoiceFormPreview({
+  currency,
+  invoiceData,
+  language,
+  onClose
+}: Props) {
+  const pdfTranslator = useTranslations('invoices.pdf');
+  const [signatureFileUrl, setSignatureFileUrl] = useState('');
+  const signature = invoiceData.senderSignature;
+
+  useEffect(() => {
+    if (!(signature instanceof File)) {
+      setSignatureFileUrl('');
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(signature);
+    setSignatureFileUrl(objectUrl);
+
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [signature]);
+
+  const senderSignatureImage =
+    typeof signature === 'string' ? signature : signatureFileUrl;
+  const pdfDocument = (
+    <PDFDocument
+      currency={currency}
+      invoiceData={invoiceData}
+      senderSignatureImage={senderSignatureImage}
+      t={pdfTranslator}
+      language={language}
+    />
+  );
+
+  return (
+    <InvoiceModal
+      pdfDocument={pdfDocument}
+      invoiceData={invoiceData}
+      invoiceLanguage={language}
+      isOpen
+      onOpenChange={(isOpen) => !isOpen && onClose()}
+    />
+  );
+}

--- a/client/src/components/invoice/invoice-form.tsx
+++ b/client/src/components/invoice/invoice-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  EyeIcon,
   InformationCircleIcon,
   UserGroupIcon,
   WalletIcon
@@ -13,6 +14,7 @@ import {
   Label,
   Radio,
   RadioGroup,
+  TextArea,
   TextField,
   Tooltip
 } from '@heroui/react';
@@ -24,11 +26,13 @@ import type {
   InvoiceBody,
   User
 } from '@invoicetrackr/types';
-import { useTranslations } from 'next-intl';
+import dynamic from 'next/dynamic';
+import { useLocale, useTranslations } from 'next-intl';
 import { type ComponentProps, useRef, useState } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 
 import useInvoiceFormSubmissionHandler from '@/lib/hooks/invoice/use-invoice-form-submission-handler';
+import useUnsavedChangesGuard from '@/lib/hooks/use-unsaved-changes-guard';
 import { Currency } from '@/lib/types/currency';
 import { splitInvoiceId } from '@/lib/utils';
 import {
@@ -36,6 +40,10 @@ import {
   formatDate,
   getDateDifferenceInDays
 } from '@/lib/utils/date';
+import {
+  buildInvoicePreviewData,
+  getDueDateAfterIssueDateChange
+} from '@/lib/utils/invoice-editor';
 
 import SignaturePad from '../signature-pad';
 import CompleteProfile from '../ui/complete-profile';
@@ -46,6 +54,10 @@ import InvoiceServicesTable from './invoice-services-table';
 import PaymentMethodDialog, {
   type PaymentMethodSelection
 } from './payment-method-dialog';
+
+const InvoiceFormPreview = dynamic(() => import('./invoice-form-preview'), {
+  ssr: false
+});
 
 type Props = {
   user: User;
@@ -102,6 +114,7 @@ const InvoiceForm = ({
   bankingInformationEntries
 }: Props) => {
   const t = useTranslations('components.invoice_form');
+  const locale = useLocale();
   const today = formatDate(new Date().toISOString());
   const defaultPaymentTermsDays = user.defaultPaymentTermsDays || 30;
   const defaultVatRate = getDefaultVatRate(user);
@@ -135,6 +148,10 @@ const InvoiceForm = ({
             user.defaultInvoiceSeries,
           paymentMode: getMvpPaymentMode(invoiceData.paymentMode),
           date: invoiceData.date ? formatDate(invoiceData.date) : today,
+          serviceDate: invoiceData.serviceDate
+            ? formatDate(invoiceData.serviceDate)
+            : formatDate(invoiceData.date),
+          notes: invoiceData.notes || '',
           dueDate: invoiceData.dueDate ? formatDate(invoiceData.dueDate) : ''
         }
       : {
@@ -149,6 +166,7 @@ const InvoiceForm = ({
           services: [
             {
               amount: 0,
+              position: 0,
               quantity: 1,
               description: '',
               unit: 'service',
@@ -162,14 +180,17 @@ const InvoiceForm = ({
           paymentMode: 'manual',
           manualPaymentReference: '',
           date: today,
+          serviceDate: today,
+          notes: '',
           dueDate: addDaysToDate(today, defaultPaymentTermsDays),
           senderSignature: defaultSenderSignature || ''
         }
   });
   const {
     handleSubmit,
+    getValues,
     setError,
-    formState: { errors, isSubmitting },
+    formState: { errors, isDirty, isSubmitting },
     clearErrors,
     setValue,
     control,
@@ -182,11 +203,28 @@ const InvoiceForm = ({
   const [senderSignature, setSenderSignature] = useState<
     string | File | undefined
   >(defaultSenderSignature);
+  const [previewData, setPreviewData] = useState<InvoiceBody | null>(null);
+  const isDueDateManuallyOverriddenRef = useRef(
+    Boolean(
+      invoiceData &&
+        getDateDifferenceInDays(invoiceData.date, invoiceData.dueDate) !==
+          defaultPaymentTermsDays
+    )
+  );
+  const isServiceDateManuallyOverriddenRef = useRef(
+    Boolean(invoiceData && invoiceData.serviceDate !== invoiceData.date)
+  );
+
+  const { confirmNavigation, disableGuard } = useUnsavedChangesGuard({
+    isDirty,
+    message: t('unsaved_changes')
+  });
 
   const { onSubmit, redirectToInvoicesPage } = useInvoiceFormSubmissionHandler({
     invoiceData,
     user,
-    setError
+    setError,
+    onSuccess: disableGuard
   });
 
   const dueDateInputRef = useRef<HTMLInputElement | null>(null);
@@ -208,12 +246,18 @@ const InvoiceForm = ({
   };
 
   const handleSelectReceiver = (receiver: ClientBody) => {
-    setValue('receiver.businessType', receiver.businessType);
-    setValue('receiver.name', receiver.name);
-    setValue('receiver.businessNumber', receiver.businessNumber);
-    setValue('receiver.vatNumber', isVatEnabled ? receiver.vatNumber : '');
-    setValue('receiver.address', receiver.address);
-    setValue('receiver.email', receiver.email);
+    setValue('receiver.businessType', receiver.businessType, {
+      shouldDirty: true
+    });
+    setValue('receiver.name', receiver.name, { shouldDirty: true });
+    setValue('receiver.businessNumber', receiver.businessNumber, {
+      shouldDirty: true
+    });
+    setValue('receiver.vatNumber', isVatEnabled ? receiver.vatNumber : '', {
+      shouldDirty: true
+    });
+    setValue('receiver.address', receiver.address, { shouldDirty: true });
+    setValue('receiver.email', receiver.email, { shouldDirty: true });
     clearErrors('receiver');
     setIsReceiverModalOpen(false);
   };
@@ -250,6 +294,14 @@ const InvoiceForm = ({
     setSenderSignature(signature);
     setValue('senderSignature', signature, { shouldDirty: true });
     clearErrors('senderSignature');
+  };
+
+  const handleCancel = () => {
+    if (confirmNavigation()) redirectToInvoicesPage();
+  };
+
+  const handlePreview = () => {
+    setPreviewData(buildInvoicePreviewData(getValues()));
   };
 
   const renderTextField = ({
@@ -800,12 +852,21 @@ const InvoiceForm = ({
         <Button
           variant="ghost"
           className="w-full sm:w-auto"
-          onPress={redirectToInvoicesPage}
+          onPress={handleCancel}
         >
           {t('buttons.cancel')}
         </Button>
         <Button
-          isDisabled={!methods.formState.isDirty || isSubmitting}
+          type="button"
+          variant="secondary"
+          className="w-full sm:w-auto"
+          onPress={handlePreview}
+        >
+          <EyeIcon className="h-5 w-5" />
+          {t('buttons.preview')}
+        </Button>
+        <Button
+          isDisabled={!isDirty || isSubmitting}
           type="submit"
           className="w-full sm:w-auto"
         >
@@ -836,7 +897,7 @@ const InvoiceForm = ({
           >
             <div className="col-span-4 flex flex-col gap-4">
               <h4>{t('invoice_details')}</h4>
-              <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-3">
+              <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-4">
                 <Controller
                   name="invoiceSeries"
                   control={control}
@@ -879,7 +940,47 @@ const InvoiceForm = ({
                       inputProps: {
                         ...field,
                         value: field.value || today,
+                        onChange: (event) => {
+                          field.onChange(event);
+                          if (!isServiceDateManuallyOverriddenRef.current) {
+                            setValue('serviceDate', event.target.value, {
+                              shouldDirty: true
+                            });
+                          }
+                          setValue(
+                            'dueDate',
+                            getDueDateAfterIssueDateChange({
+                              issueDate: event.target.value,
+                              currentDueDate: getValues('dueDate'),
+                              paymentTermsDays: defaultPaymentTermsDays,
+                              isManuallyOverridden:
+                                isDueDateManuallyOverriddenRef.current
+                            }),
+                            { shouldDirty: true }
+                          );
+                        },
                         'aria-label': t('a11y.date_label'),
+                        type: 'date'
+                      }
+                    })
+                  }
+                />
+                <Controller
+                  name="serviceDate"
+                  control={control}
+                  render={({ field }) =>
+                    renderTextField({
+                      label: t('labels.service_date'),
+                      isInvalid: !!errors.serviceDate,
+                      errorMessage: errors.serviceDate?.message,
+                      inputProps: {
+                        ...field,
+                        value: field.value || currentDate || today,
+                        onChange: (event) => {
+                          isServiceDateManuallyOverriddenRef.current = true;
+                          field.onChange(event);
+                        },
+                        'aria-label': t('a11y.service_date_label'),
                         type: 'date'
                       }
                     })
@@ -899,6 +1000,7 @@ const InvoiceForm = ({
                           onDueDatePreselectionChange={(
                             dueDatePreselection
                           ) => {
+                            isDueDateManuallyOverriddenRef.current = true;
                             const currentDatePlusDays = new Date(currentDate);
 
                             if (dueDatePreselection === 'custom') {
@@ -930,6 +1032,10 @@ const InvoiceForm = ({
                             {...field}
                             ref={dueDateInputRef}
                             value={field.value || ''}
+                            onChange={(event) => {
+                              isDueDateManuallyOverriddenRef.current = true;
+                              field.onChange(event);
+                            }}
                             aria-label={t('a11y.due_date_label')}
                             type="date"
                           />
@@ -943,6 +1049,32 @@ const InvoiceForm = ({
             </div>
             {renderSenderAndReceiverFields()}
             {renderInvoiceServices()}
+            <div className="col-span-4">
+              <Controller
+                name="notes"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    className="w-full"
+                    variant="secondary"
+                    isInvalid={!!errors.notes}
+                  >
+                    <Label>{t('labels.notes')}</Label>
+                    <TextArea
+                      name={field.name}
+                      value={field.value || ''}
+                      rows={4}
+                      maxLength={2000}
+                      aria-label={t('a11y.notes_label')}
+                      placeholder={t('placeholders.notes')}
+                      onBlur={field.onBlur}
+                      onChange={field.onChange}
+                    />
+                    <FieldError>{errors.notes?.message}</FieldError>
+                  </TextField>
+                )}
+              />
+            </div>
             {renderPaymentSettings()}
             {renderInvoiceSignature()}
             {renderActions()}
@@ -965,6 +1097,14 @@ const InvoiceForm = ({
         cryptoWallets={cryptoWallets}
         onSelect={handlePaymentMethodSelect}
       />
+      {previewData && (
+        <InvoiceFormPreview
+          currency={currency}
+          invoiceData={previewData}
+          language={locale}
+          onClose={() => setPreviewData(null)}
+        />
+      )}
     </>
   );
 };

--- a/client/src/components/invoice/invoice-services-table.tsx
+++ b/client/src/components/invoice/invoice-services-table.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  PlusIcon,
+  TrashIcon
+} from '@heroicons/react/24/outline';
 import {
   Button,
   Chip,
@@ -71,9 +76,10 @@ const InvoiceServicesTable = ({
     clearErrors,
     formState: { errors }
   } = useFormContext<InvoiceBody>();
-  const { fields, append, remove, replace } = useFieldArray({
+  const { fields, append, move, remove, replace } = useFieldArray({
     name: 'services',
-    control
+    control,
+    keyName: 'fieldId'
   });
   const servicesTableRef = useRef<HTMLDivElement>(null);
 
@@ -123,12 +129,7 @@ const InvoiceServicesTable = ({
   const lineTotals = useMemo(
     () =>
       services.map((service) => {
-        const amount = Number(service?.amount) || 0;
-        const quantity = Number(service?.quantity) || 0;
-        const vatRate = Number(service?.vatRate ?? 0) || 0;
-        const subtotal = amount * quantity;
-
-        return subtotal + subtotal * (vatRate / 100);
+        return calculateInvoiceTotals([service]).totalAmount;
       }),
     [services]
   );
@@ -136,7 +137,11 @@ const InvoiceServicesTable = ({
   useEffect(() => {
     if (!invoiceServices?.length) return;
 
-    replace(invoiceServices);
+    replace(
+      [...invoiceServices].sort(
+        (first, second) => (first.position ?? 0) - (second.position ?? 0)
+      )
+    );
   }, [invoiceServices, replace]);
 
   useEffect(() => {
@@ -186,6 +191,7 @@ const InvoiceServicesTable = ({
   const handleAddService = () => {
     append({
       id: 0,
+      position: fields.length,
       amount: 0,
       description: '',
       quantity: 1,
@@ -198,6 +204,7 @@ const InvoiceServicesTable = ({
   };
 
   const handleRemoveService = (index: number) => {
+    if (fields.length === 1) return;
     remove(index);
   };
 
@@ -305,9 +312,8 @@ const InvoiceServicesTable = ({
                 className="w-full min-w-28"
                 variant="secondary"
                 allowsCustomValue
-                inputValue={localizeInvoiceUnit(
-                  field.value || '',
-                  (unit) => t(`units.${unit}`)
+                inputValue={localizeInvoiceUnit(field.value || '', (unit) =>
+                  t(`units.${unit}`)
                 )}
                 onInputChange={field.onChange}
                 onSelectionChange={(key) => key && field.onChange(String(key))}
@@ -403,7 +409,7 @@ const InvoiceServicesTable = ({
         return (
           <p className="min-w-20 text-left text-sm font-medium">
             {getCurrencySymbol(currency)}
-            {(lineTotals[index] || 0).toFixed(2)}
+            {lineTotals[index] || '0.00'}
           </p>
         );
       case 'actions':
@@ -413,11 +419,36 @@ const InvoiceServicesTable = ({
             className="relative flex items-center gap-2"
           >
             <Button
-              aria-label={t('delete_service')}
-              onPress={() => handleRemoveService(index)}
+              isIconOnly
+              size="sm"
+              aria-label={t('move_service_up')}
+              onPress={() => move(index, index - 1)}
+              isDisabled={index === 0}
               variant="tertiary"
               data-invoice-service-focusable
-              className="text-danger min-w-min cursor-pointer p-3 text-lg active:opacity-50"
+            >
+              <ArrowUpIcon className="h-4 w-4" />
+            </Button>
+            <Button
+              isIconOnly
+              size="sm"
+              aria-label={t('move_service_down')}
+              onPress={() => move(index, index + 1)}
+              isDisabled={index === fields.length - 1}
+              variant="tertiary"
+              data-invoice-service-focusable
+            >
+              <ArrowDownIcon className="h-4 w-4" />
+            </Button>
+            <Button
+              isIconOnly
+              size="sm"
+              aria-label={t('delete_service')}
+              onPress={() => handleRemoveService(index)}
+              isDisabled={fields.length === 1}
+              variant="tertiary"
+              data-invoice-service-focusable
+              className="text-danger"
             >
               <TrashIcon className="h-5 w-5" />
             </Button>
@@ -451,7 +482,7 @@ const InvoiceServicesTable = ({
             </TableHeader>
             <TableBody>
               {fields.map((field, index) => (
-                <TableRow key={field.id} id={`service-${index}`}>
+                <TableRow key={field.fieldId} id={`service-${index}`}>
                   {visibleColumns.map((column) => (
                     <TableCell key={column.uid}>
                       {renderCell(column.uid, index)}

--- a/client/src/components/invoice/signing/invoice-signing-summary.tsx
+++ b/client/src/components/invoice/signing/invoice-signing-summary.tsx
@@ -125,10 +125,7 @@ export default function InvoiceSigningSummary({
             </thead>
             <tbody>
               {invoice.services.map((service, index) => {
-                const subtotal =
-                  Number(service.amount) * Number(service.quantity);
-                const lineTotal =
-                  subtotal * (1 + Number(service.vatRate ?? 0) / 100);
+                const lineTotal = calculateInvoiceTotals([service]).totalAmount;
 
                 return (
                   <tr
@@ -153,7 +150,7 @@ export default function InvoiceSigningSummary({
                     )}
                     <td className="px-2 py-3 text-right font-medium">
                       {currencySymbol}
-                      {lineTotal.toFixed(2)}
+                      {lineTotal}
                     </td>
                   </tr>
                 );

--- a/client/src/components/pdf/pdf-document.tsx
+++ b/client/src/components/pdf/pdf-document.tsx
@@ -41,8 +41,16 @@ export default function PDFDocument({
   language,
   showDraftState = true
 }: Props) {
-  const { date, dueDate, invoiceId, receiver, sender, services, totalAmount } =
-    invoiceData;
+  const {
+    date,
+    serviceDate,
+    dueDate,
+    invoiceId,
+    receiver,
+    sender,
+    services,
+    totalAmount
+  } = invoiceData;
   const invoiceTotals = calculateInvoiceTotals(services);
   const subtotalAmount =
     invoiceData.subtotalAmount || invoiceTotals.subtotalAmount;
@@ -129,6 +137,12 @@ export default function PDFDocument({
           <Text style={pdfStyles.detailItem}>
             {date ? formatDate(date) : ''}
           </Text>
+          <Text style={[pdfStyles.detailItem, pdfStyles.boldText]}>
+            {t('service_date_label')}
+          </Text>
+          <Text style={pdfStyles.detailItem}>
+            {serviceDate ? formatDate(serviceDate) : formatDate(date)}
+          </Text>
         </View>
       </View>
 
@@ -191,11 +205,7 @@ export default function PDFDocument({
       )}
       <View style={[pdfStyles.tableCol, lineTotalColumnStyle]}>
         <Text style={pdfStyles.tableCell}>
-          {(
-            Number(amount) *
-            Number(quantity) *
-            (1 + Number(vatRate ?? 0) / 100)
-          ).toFixed(2)}{' '}
+          {calculateInvoiceTotals([{ amount, quantity, vatRate }]).totalAmount}{' '}
           {currency.toUpperCase()}
         </Text>
       </View>
@@ -374,6 +384,11 @@ export default function PDFDocument({
       invoiceData.manualPaymentReference ? (
         <Text style={pdfStyles.footerItem}>
           {t('payment_reference_label')}: {invoiceData.manualPaymentReference}
+        </Text>
+      ) : null}
+      {invoiceData.notes ? (
+        <Text style={pdfStyles.footerItem}>
+          {t('notes_label')}: {invoiceData.notes}
         </Text>
       ) : null}
     </View>

--- a/client/src/lib/hooks/__tests__/use-unsaved-changes-guard.test.tsx
+++ b/client/src/lib/hooks/__tests__/use-unsaved-changes-guard.test.tsx
@@ -1,0 +1,66 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import useUnsavedChangesGuard from '../use-unsaved-changes-guard';
+
+describe('useUnsavedChangesGuard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('confirms dirty navigation and leaves the guard active when canceled', () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({ isDirty: true, message: 'Leave?' })
+    );
+
+    expect(result.current.confirmNavigation()).toBe(false);
+    expect(confirm).toHaveBeenCalledWith('Leave?');
+
+    const event = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('disables unload protection after a successful save', () => {
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({ isDirty: true, message: 'Leave?' })
+    );
+
+    act(() => result.current.disableGuard());
+
+    const event = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('blocks internal links when the user keeps editing', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    renderHook(() =>
+      useUnsavedChangesGuard({ isDirty: true, message: 'Leave?' })
+    );
+    const anchor = document.createElement('a');
+    anchor.href = '/invoices';
+    document.body.append(anchor);
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    anchor.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    anchor.remove();
+  });
+
+  it('restores the guarded history entry when back navigation is canceled', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const forward = vi
+      .spyOn(window.history, 'forward')
+      .mockImplementation(() => {});
+    renderHook(() =>
+      useUnsavedChangesGuard({ isDirty: true, message: 'Leave?' })
+    );
+
+    window.dispatchEvent(new PopStateEvent('popstate'));
+
+    expect(forward).toHaveBeenCalledOnce();
+  });
+});

--- a/client/src/lib/hooks/invoice/use-invoice-form-submission-handler.ts
+++ b/client/src/lib/hooks/invoice/use-invoice-form-submission-handler.ts
@@ -14,13 +14,15 @@ type Props = {
   user: User | undefined;
   bankingInformation?: BankAccount;
   setError: UseFormSetError<InvoiceBody>;
+  onSuccess?: () => void;
 };
 
 const useInvoiceFormSubmissionHandler = ({
   invoiceData,
   user,
   bankingInformation,
-  setError
+  setError,
+  onSuccess
 }: Props) => {
   const router = useRouter();
 
@@ -36,6 +38,12 @@ const useInvoiceFormSubmissionHandler = ({
 
     const fullData: typeof data = {
       ...data,
+      serviceDate: data.serviceDate || data.date,
+      notes: data.notes?.trim() || null,
+      services: data.services.map((service, position) => ({
+        ...service,
+        position
+      })),
       senderSignature: data.senderSignature || '',
       subtotalAmount: invoiceTotals.subtotalAmount,
       vatAmount: invoiceTotals.vatAmount,
@@ -71,6 +79,7 @@ const useInvoiceFormSubmissionHandler = ({
       return;
     }
 
+    onSuccess?.();
     redirectToInvoicesPage();
   };
 

--- a/client/src/lib/hooks/use-unsaved-changes-guard.ts
+++ b/client/src/lib/hooks/use-unsaved-changes-guard.ts
@@ -1,0 +1,117 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+
+const HISTORY_GUARD_KEY = '__invoiceTrackrUnsavedChangesGuard';
+
+export default function useUnsavedChangesGuard({
+  isDirty,
+  message
+}: {
+  isDirty: boolean;
+  message: string;
+}) {
+  const isGuardEnabledRef = useRef(isDirty);
+  const hasHistoryEntryRef = useRef(false);
+  const isRestoringHistoryRef = useRef(false);
+
+  useEffect(() => {
+    isGuardEnabledRef.current = isDirty;
+  }, [isDirty]);
+
+  const disableGuard = useCallback(() => {
+    isGuardEnabledRef.current = false;
+  }, []);
+
+  const confirmNavigation = useCallback(() => {
+    if (!isGuardEnabledRef.current || window.confirm(message)) {
+      disableGuard();
+      return true;
+    }
+
+    return false;
+  }, [disableGuard, message]);
+
+  useEffect(() => {
+    if (!isDirty || hasHistoryEntryRef.current) return;
+
+    window.history.pushState(
+      { ...window.history.state, [HISTORY_GUARD_KEY]: true },
+      '',
+      window.location.href
+    );
+    hasHistoryEntryRef.current = true;
+  }, [isDirty]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!isGuardEnabledRef.current) return;
+
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    const handleDocumentClick = (event: MouseEvent) => {
+      if (!isGuardEnabledRef.current || event.defaultPrevented) return;
+
+      const target = event.target;
+      const anchor =
+        target instanceof Element
+          ? target.closest<HTMLAnchorElement>('a[href]')
+          : null;
+
+      if (
+        !anchor ||
+        anchor.target === '_blank' ||
+        anchor.hasAttribute('download') ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      )
+        return;
+
+      const destination = new URL(anchor.href, window.location.href);
+      if (destination.origin !== window.location.origin) return;
+      if (
+        destination.pathname === window.location.pathname &&
+        destination.search === window.location.search &&
+        destination.hash
+      )
+        return;
+
+      if (confirmNavigation()) return;
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    };
+
+    const handlePopState = () => {
+      if (isRestoringHistoryRef.current) {
+        isRestoringHistoryRef.current = false;
+        return;
+      }
+      if (!isGuardEnabledRef.current) return;
+
+      if (window.confirm(message)) {
+        disableGuard();
+        window.history.back();
+      } else {
+        isRestoringHistoryRef.current = true;
+        window.history.forward();
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('popstate', handlePopState);
+    document.addEventListener('click', handleDocumentClick, true);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopState);
+      document.removeEventListener('click', handleDocumentClick, true);
+    };
+  }, [confirmNavigation, disableGuard, message]);
+
+  return { confirmNavigation, disableGuard };
+}

--- a/client/src/lib/utils/__tests__/invoice-editor.test.ts
+++ b/client/src/lib/utils/__tests__/invoice-editor.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildInvoicePreviewData,
+  getDueDateAfterIssueDateChange
+} from '../invoice-editor';
+
+describe('invoice editor utilities', () => {
+  it('derives the due date from profile payment terms until manually overridden', () => {
+    expect(
+      getDueDateAfterIssueDateChange({
+        issueDate: '2026-08-25',
+        currentDueDate: '2026-09-24',
+        paymentTermsDays: 14,
+        isManuallyOverridden: false
+      })
+    ).toBe('2026-09-08');
+
+    expect(
+      getDueDateAfterIssueDateChange({
+        issueDate: '2026-08-26',
+        currentDueDate: '2026-09-30',
+        paymentTermsDays: 14,
+        isManuallyOverridden: true
+      })
+    ).toBe('2026-09-30');
+  });
+
+  it('builds a detached draft preview with recalculated totals and positions', () => {
+    const formData = {
+      date: '2026-08-25',
+      serviceDate: '2026-08-24',
+      dueDate: '2026-09-08',
+      notes: 'Visible note',
+      sender: {
+        name: 'Sender',
+        businessType: 'individual' as const,
+        businessNumber: 'IV-1',
+        address: 'Vilnius',
+        type: 'sender' as const
+      },
+      receiver: {
+        name: 'Client',
+        businessType: 'business' as const,
+        businessNumber: '123',
+        address: 'Kaunas',
+        type: 'receiver' as const
+      },
+      services: [
+        {
+          description: 'Second',
+          unit: 'hour',
+          quantity: 1.25,
+          amount: 80.4,
+          vatRate: 21
+        },
+        {
+          description: 'First',
+          unit: 'service',
+          quantity: 0.5,
+          amount: 10,
+          vatRate: 0
+        }
+      ],
+      subtotalAmount: '999.00',
+      vatAmount: '999.00',
+      totalAmount: '999.00',
+      status: 'pending' as const,
+      lifecycleStatus: 'issued' as const,
+      paymentMode: 'disabled' as const
+    };
+
+    const preview = buildInvoicePreviewData(formData);
+
+    expect(preview).not.toBe(formData);
+    expect(preview.lifecycleStatus).toBe('draft');
+    expect(preview.services.map((service) => service.position)).toEqual([0, 1]);
+    expect(preview).toMatchObject({
+      subtotalAmount: '105.50',
+      vatAmount: '21.11',
+      totalAmount: '126.61'
+    });
+    expect(formData.totalAmount).toBe('999.00');
+  });
+});

--- a/client/src/lib/utils/index.ts
+++ b/client/src/lib/utils/index.ts
@@ -33,18 +33,40 @@ export const getDaysUntilDueDate = (date: string, dueDate: string) => {
 export const calculateServiceTotal = (services: Array<InvoiceServiceBody>) =>
   Number(calculateInvoiceTotals(services).totalAmount);
 
-const toMoney = (amountInCents: number) => (amountInCents / 100).toFixed(2);
+const parseScaledDecimal = (
+  value: number | string | null | undefined,
+  scale: number
+) => {
+  const decimal = String(value ?? 0).trim();
+  const match = decimal.match(/^(\d+)(?:\.(\d+))?$/);
+
+  if (!match) return 0n;
+
+  const factor = 10n ** BigInt(scale);
+  const fraction = (match[2] || '').padEnd(scale, '0').slice(0, scale);
+
+  return BigInt(match[1]) * factor + BigInt(fraction || '0');
+};
+
+const roundPositiveDivision = (value: bigint, divisor: bigint) =>
+  (value + divisor / 2n) / divisor;
+
+const toMoney = (amountInCents: bigint) =>
+  `${amountInCents / 100n}.${String(amountInCents % 100n).padStart(2, '0')}`;
 
 export const calculateInvoiceTotals = (
   services: Array<Pick<InvoiceServiceBody, 'amount' | 'quantity' | 'vatRate'>>
 ) => {
   const totals = services.reduce(
     (acc, service) => {
-      const subtotalCents = Math.round(
-        Number(service.amount) * Number(service.quantity) * 100
+      const subtotalCents = roundPositiveDivision(
+        parseScaledDecimal(service.amount, 2) *
+          parseScaledDecimal(service.quantity, 4),
+        10_000n
       );
-      const vatCents = Math.round(
-        subtotalCents * (Number(service.vatRate ?? 0) / 100)
+      const vatCents = roundPositiveDivision(
+        subtotalCents * parseScaledDecimal(service.vatRate, 2),
+        10_000n
       );
 
       return {
@@ -52,7 +74,7 @@ export const calculateInvoiceTotals = (
         vatCents: acc.vatCents + vatCents
       };
     },
-    { subtotalCents: 0, vatCents: 0 }
+    { subtotalCents: 0n, vatCents: 0n }
   );
 
   return {

--- a/client/src/lib/utils/invoice-editor.ts
+++ b/client/src/lib/utils/invoice-editor.ts
@@ -1,0 +1,36 @@
+import type { InvoiceBody } from '@invoicetrackr/types';
+
+import { calculateInvoiceTotals } from '@/lib/utils';
+import { addDaysToDate } from '@/lib/utils/date';
+
+export const getDueDateAfterIssueDateChange = ({
+  issueDate,
+  currentDueDate,
+  paymentTermsDays,
+  isManuallyOverridden
+}: {
+  issueDate: string;
+  currentDueDate: string;
+  paymentTermsDays: number;
+  isManuallyOverridden: boolean;
+}) =>
+  issueDate && !isManuallyOverridden
+    ? addDaysToDate(issueDate, paymentTermsDays)
+    : currentDueDate;
+
+export const buildInvoicePreviewData = (formData: InvoiceBody): InvoiceBody => {
+  const totals = calculateInvoiceTotals(formData.services);
+
+  return {
+    ...formData,
+    serviceDate: formData.serviceDate || formData.date,
+    lifecycleStatus: 'draft',
+    services: formData.services.map((service, position) => ({
+      ...service,
+      position
+    })),
+    subtotalAmount: totals.subtotalAmount,
+    vatAmount: totals.vatAmount,
+    totalAmount: totals.totalAmount
+  };
+};

--- a/e2e/invoices.spec.ts
+++ b/e2e/invoices.spec.ts
@@ -7,11 +7,16 @@ test.describe('invoices', () => {
     const invoice = createInvoiceTestData('Draft recipient', {
       recipientBusinessNumber: '305000001',
       recipientAddress: 'Konstitucijos pr. 7, Vilnius',
-      recipientEmail: 'draft.recipient@example.com'
+      recipientEmail: 'draft.recipient@example.com',
+      serviceDate: '2026-08-20',
+      notes: 'Thank you for your business.',
+      secondServiceDescription: 'Implementation workshop'
     });
 
     await invoiceForm.createDraft(invoice);
     await invoicesPage.expectLifecycle(invoice.recipientName, 'Draft');
+    await invoicesPage.openDraftForEditing(invoice.recipientName);
+    await invoiceForm.expectPersistedDraft(invoice);
   });
 
   test('recipient completion issues the draft', async ({

--- a/e2e/pages/invoice-form.page.ts
+++ b/e2e/pages/invoice-form.page.ts
@@ -13,6 +13,10 @@ export class InvoiceFormPage {
 
     await this.page.getByLabel("Receiver's Name").fill(invoice.recipientName);
 
+    if (invoice.serviceDate) {
+      await this.page.getByLabel('Service date').fill(invoice.serviceDate);
+    }
+
     if (invoice.recipientBusinessNumber) {
       await this.page
         .getByLabel("Receiver's Company Code")
@@ -43,6 +47,36 @@ export class InvoiceFormPage {
       .getByRole('spinbutton', { name: 'Unit price', exact: true })
       .first()
       .fill(invoice.unitPrice);
+
+    if (invoice.secondServiceDescription) {
+      await this.page.getByRole('button', { name: 'Add Service' }).click();
+      await this.page
+        .getByRole('textbox', { name: 'Description', exact: true })
+        .nth(1)
+        .fill(invoice.secondServiceDescription);
+      await this.page
+        .getByRole('spinbutton', { name: 'Quantity', exact: true })
+        .nth(1)
+        .fill('1.25');
+      await this.page
+        .getByRole('spinbutton', { name: 'Unit price', exact: true })
+        .nth(1)
+        .fill('80.40');
+      await this.page
+        .getByRole('button', { name: 'Move service up' })
+        .nth(1)
+        .click();
+    }
+
+    if (invoice.notes) {
+      await this.page.getByLabel('Client-visible notes').fill(invoice.notes);
+    }
+
+    if (invoice.secondServiceDescription) {
+      await this.page.getByRole('button', { name: 'Preview' }).click();
+      await expect(this.page.getByRole('dialog')).toBeVisible();
+      await this.page.getByRole('button', { name: 'Close' }).last().click();
+    }
     const noPaymentRadio = this.page.getByRole('radio', {
       name: 'No payment block'
     });
@@ -51,5 +85,34 @@ export class InvoiceFormPage {
     await this.page.getByRole('button', { name: /^Save$/ }).click();
 
     await expect(this.page).toHaveURL(/\/invoices$/);
+  }
+
+  async expectPersistedDraft(invoice: InvoiceTestData) {
+    await expect(
+      this.page.getByRole('form', { name: 'Add New Invoice Form' })
+    ).toBeVisible();
+
+    if (invoice.serviceDate) {
+      await expect(this.page.getByLabel('Service date')).toHaveValue(
+        invoice.serviceDate
+      );
+    }
+
+    if (invoice.notes) {
+      await expect(this.page.getByLabel('Client-visible notes')).toHaveValue(
+        invoice.notes
+      );
+    }
+
+    if (invoice.secondServiceDescription) {
+      const descriptions = this.page.getByRole('textbox', {
+        name: 'Description',
+        exact: true
+      });
+      await expect(descriptions.nth(0)).toHaveValue(
+        invoice.secondServiceDescription
+      );
+      await expect(descriptions.nth(1)).toHaveValue(invoice.serviceDescription);
+    }
   }
 }

--- a/e2e/pages/invoices.page.ts
+++ b/e2e/pages/invoices.page.ts
@@ -36,6 +36,13 @@ export class InvoicesPage {
     await expect(this.rowFor(recipientName)).toContainText(/SF\d{3}/);
   }
 
+  async openDraftForEditing(recipientName: string) {
+    await this.rowFor(recipientName)
+      .locator('button[aria-label="Edit invoice"]')
+      .click();
+    await expect(this.page).toHaveURL(/\/invoices\/edit\/\d+$/);
+  }
+
   private async readClipboard() {
     return this.page.evaluate(() => navigator.clipboard.readText());
   }

--- a/e2e/utils/test-data.ts
+++ b/e2e/utils/test-data.ts
@@ -12,6 +12,9 @@ export type InvoiceTestData = {
   recipientAddress?: string;
   recipientEmail?: string;
   serviceDescription: string;
+  secondServiceDescription?: string;
+  serviceDate?: string;
+  notes?: string;
   quantity: string;
   unitPrice: string;
 };

--- a/server/drizzle/0041_rek_101_invoice_editor_hardening.sql
+++ b/server/drizzle/0041_rek_101_invoice_editor_hardening.sql
@@ -1,0 +1,21 @@
+ALTER TABLE "invoices" ADD COLUMN "service_date" date;
+UPDATE "invoices" SET "service_date" = "date" WHERE "service_date" IS NULL;
+ALTER TABLE "invoices" ALTER COLUMN "service_date" SET NOT NULL;
+
+ALTER TABLE "invoices" ADD COLUMN "notes" text;
+
+ALTER TABLE "invoice_services" ADD COLUMN "position" integer;
+WITH ordered_services AS (
+  SELECT "id", (row_number() OVER (PARTITION BY "invoice_id" ORDER BY "id") - 1)::integer AS "position"
+  FROM "invoice_services"
+)
+UPDATE "invoice_services"
+SET "position" = ordered_services."position"
+FROM ordered_services
+WHERE "invoice_services"."id" = ordered_services."id";
+ALTER TABLE "invoice_services" ALTER COLUMN "position" SET NOT NULL;
+ALTER TABLE "invoice_services" ADD CONSTRAINT "invoice_services_position_check" CHECK ("position" >= 0);
+
+ALTER TABLE "invoices" ALTER COLUMN "subtotal_amount" SET DATA TYPE numeric(16,2);
+ALTER TABLE "invoices" ALTER COLUMN "vat_amount" SET DATA TYPE numeric(16,2);
+ALTER TABLE "invoices" ALTER COLUMN "total_amount" SET DATA TYPE numeric(16,2);

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1787669499000,
       "tag": "0040_rek_100_client_archiving",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1787689800000,
+      "tag": "0041_rek_101_invoice_editor_hardening",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/controllers/__tests__/invoice.ts
+++ b/server/src/controllers/__tests__/invoice.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_CURRENCY,
+  invoiceBodySchema,
   invoiceServiceBodySchema
 } from '@invoicetrackr/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -652,6 +653,51 @@ describe('Invoice Controller', () => {
         expect(result.error.issues.at(0)?.message).toBe(
           'validation.invoice.services.quantity.scale'
         );
+    });
+
+    it('rejects unit prices and VAT rates with more than two decimal places', () => {
+      expect(
+        invoiceServiceBodySchema.safeParse({
+          ...service,
+          quantity: 1,
+          amount: 10.001
+        }).success
+      ).toBe(false);
+      expect(
+        invoiceServiceBodySchema.safeParse({
+          ...service,
+          quantity: 1,
+          vatRate: 21.001
+        }).success
+      ).toBe(false);
+    });
+  });
+
+  describe('service date and notes validation', () => {
+    it('accepts a valid service date and trims recipient-visible notes', () => {
+      const result = invoiceBodySchema.safeParse({
+        ...mockInvoice,
+        serviceDate: '2026-08-25',
+        notes: '  Thank you  '
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.notes).toBe('Thank you');
+    });
+
+    it('rejects an invalid service date and notes over 2,000 characters', () => {
+      expect(
+        invoiceBodySchema.safeParse({
+          ...mockInvoice,
+          serviceDate: '25-08-2026'
+        }).success
+      ).toBe(false);
+      expect(
+        invoiceBodySchema.safeParse({
+          ...mockInvoice,
+          notes: 'x'.repeat(2001)
+        }).success
+      ).toBe(false);
     });
   });
 

--- a/server/src/database/invoice.ts
+++ b/server/src/database/invoice.ts
@@ -12,7 +12,10 @@ import {
   sql
 } from 'drizzle-orm';
 
-import { calculateInvoiceTotals } from '../utils/invoice';
+import {
+  calculateInvoiceTotals,
+  positionInvoiceServices
+} from '../utils/invoice';
 import { jsonAgg } from '../utils/json';
 import { db } from './db';
 import {
@@ -246,6 +249,8 @@ export const getInvoicesFromDb = async (
       invoiceId: invoicesTable.invoiceId,
       invoiceSeries: invoicesTable.invoiceSeries,
       date: invoicesTable.date,
+      serviceDate: invoicesTable.serviceDate,
+      notes: invoicesTable.notes,
       subtotalAmount: invoicesTable.subtotalAmount,
       vatAmount: invoicesTable.vatAmount,
       totalAmount: invoicesTable.totalAmount,
@@ -311,15 +316,19 @@ export const getInvoicesFromDb = async (
         address: invoiceReceiversTable.address,
         email: invoiceReceiversTable.email
       },
-      services: jsonAgg({
-        id: invoiceServicesTable.id,
-        description: invoiceServicesTable.description,
-        amount: invoiceServicesTable.amount,
-        quantity: invoiceServicesTable.quantity,
-        unit: invoiceServicesTable.unit,
-        vatRate: invoiceServicesTable.vatRate,
-        vatExemptionReason: invoiceServicesTable.vatExemptionReason
-      })
+      services: jsonAgg(
+        {
+          id: invoiceServicesTable.id,
+          position: invoiceServicesTable.position,
+          description: invoiceServicesTable.description,
+          amount: invoiceServicesTable.amount,
+          quantity: invoiceServicesTable.quantity,
+          unit: invoiceServicesTable.unit,
+          vatRate: invoiceServicesTable.vatRate,
+          vatExemptionReason: invoiceServicesTable.vatExemptionReason
+        },
+        invoiceServicesTable.position
+      )
     })
     .from(invoicesTable)
     .leftJoin(
@@ -366,6 +375,8 @@ export const getInvoiceFromDb = async (
       invoiceId: invoicesTable.invoiceId,
       invoiceSeries: invoicesTable.invoiceSeries,
       date: invoicesTable.date,
+      serviceDate: invoicesTable.serviceDate,
+      notes: invoicesTable.notes,
       subtotalAmount: invoicesTable.subtotalAmount,
       vatAmount: invoicesTable.vatAmount,
       totalAmount: invoicesTable.totalAmount,
@@ -431,15 +442,19 @@ export const getInvoiceFromDb = async (
         address: invoiceReceiversTable.address,
         email: invoiceReceiversTable.email
       },
-      services: jsonAgg({
-        id: invoiceServicesTable.id,
-        description: invoiceServicesTable.description,
-        amount: invoiceServicesTable.amount,
-        quantity: invoiceServicesTable.quantity,
-        unit: invoiceServicesTable.unit,
-        vatRate: invoiceServicesTable.vatRate,
-        vatExemptionReason: invoiceServicesTable.vatExemptionReason
-      })
+      services: jsonAgg(
+        {
+          id: invoiceServicesTable.id,
+          position: invoiceServicesTable.position,
+          description: invoiceServicesTable.description,
+          amount: invoiceServicesTable.amount,
+          quantity: invoiceServicesTable.quantity,
+          unit: invoiceServicesTable.unit,
+          vatRate: invoiceServicesTable.vatRate,
+          vatExemptionReason: invoiceServicesTable.vatExemptionReason
+        },
+        invoiceServicesTable.position
+      )
     })
     .from(invoicesTable)
     .leftJoin(
@@ -496,6 +511,8 @@ export const insertInvoiceInDb = async (
       .values({
         userId,
         date: invoiceData.date,
+        serviceDate: invoiceData.serviceDate || invoiceData.date,
+        notes: invoiceData.notes?.trim() || null,
         invoiceId: null,
         invoiceSeries,
         subtotalAmount: totals.subtotalAmount,
@@ -591,8 +608,9 @@ export const insertInvoiceInDb = async (
     }
 
     // Invoice services insert
-    for (const service of invoiceData.services) {
+    for (const service of positionInvoiceServices(invoiceData.services)) {
       await tx.insert(invoiceServicesTable).values({
+        position: service.position,
         quantity: String(service.quantity),
         amount: String(service.amount),
         vatRate: String(service.vatRate || 0),
@@ -827,7 +845,9 @@ export const updateInvoiceInDb = async (
         bankAccountId: currentInvoiceData.bankAccountId,
         cryptoWalletId: currentInvoiceData.cryptoWalletId,
         date: invoiceData.date,
+        serviceDate: invoiceData.serviceDate || invoiceData.date,
         dueDate: invoiceData.dueDate,
+        notes: invoiceData.notes?.trim() || null,
         status: 'pending',
         lifecycleStatus: currentInvoiceData.lifecycleStatus,
         subtotalAmount: totals.subtotalAmount,
@@ -904,12 +924,13 @@ export const updateInvoiceInDb = async (
         .where(inArray(invoiceServicesTable.id, servicesToDelete));
     }
 
-    for (const service of invoiceData.services) {
+    for (const service of positionInvoiceServices(invoiceData.services)) {
       if (service.id && existingServiceIds.includes(service.id)) {
         await tx
           .update(invoiceServicesTable)
           .set({
             description: service.description,
+            position: service.position,
             amount: String(service.amount),
             vatRate: String(service.vatRate || 0),
             vatExemptionReason: service.vatExemptionReason || null,
@@ -920,6 +941,7 @@ export const updateInvoiceInDb = async (
       } else {
         await tx.insert(invoiceServicesTable).values({
           description: service.description,
+          position: service.position,
           amount: String(service.amount),
           vatRate: String(service.vatRate || 0),
           vatExemptionReason: service.vatExemptionReason || null,

--- a/server/src/database/schema.ts
+++ b/server/src/database/schema.ts
@@ -22,6 +22,7 @@ export const invoiceServicesTable = pgTable(
   {
     id: serial().primaryKey().notNull(),
     invoiceId: integer('invoice_id').notNull(),
+    position: integer().notNull(),
     description: text().notNull(),
     unit: varchar({ length: 255 }).notNull(),
     quantity: numeric({ precision: 12, scale: 4 }).notNull(),
@@ -32,6 +33,7 @@ export const invoiceServicesTable = pgTable(
     vatExemptionReason: text('vat_exemption_reason')
   },
   (table) => [
+    check('invoice_services_position_check', sql`${table.position} >= 0`),
     foreignKey({
       columns: [table.invoiceId],
       foreignColumns: [invoicesTable.id],
@@ -44,19 +46,21 @@ export const invoicesTable = pgTable(
   'invoices',
   {
     date: date().notNull(),
+    serviceDate: date('service_date').notNull(),
     userId: integer('user_id').notNull(),
     senderId: integer('sender_id'),
     receiverId: integer('receiver_id'),
     subtotalAmount: numeric('subtotal_amount', {
-      precision: 10,
+      precision: 16,
       scale: 2
     })
       .default('0')
       .notNull(),
-    vatAmount: numeric('vat_amount', { precision: 10, scale: 2 })
+    vatAmount: numeric('vat_amount', { precision: 16, scale: 2 })
       .default('0')
       .notNull(),
-    totalAmount: numeric('total_amount', { precision: 10, scale: 2 }).notNull(),
+    totalAmount: numeric('total_amount', { precision: 16, scale: 2 }).notNull(),
+    notes: text(),
     status: varchar({ length: 50 }).notNull(),
     lifecycleStatus: varchar('lifecycle_status', { length: 50 })
       .default('draft')

--- a/server/src/locales/en.ts
+++ b/server/src/locales/en.ts
@@ -116,6 +116,8 @@ export default {
         address: 'Address up to 255 characters is required',
         email: 'Valid email is required'
       },
+      serviceDate: 'A valid service date is required',
+      notes: 'Notes must not exceed 2,000 characters',
       services: {
         required: 'At least one service is required',
         description: 'Description up to 200 characters is required',
@@ -129,7 +131,11 @@ export default {
         amount: {
           number: 'Amount must be a number',
           min: 'Amount must be at least 0.01',
-          max: 'Amount must not exceed 10,000,000'
+          max: 'Amount must not exceed 10,000,000',
+          scale: 'Amount must have no more than two decimal places'
+        },
+        vatRate: {
+          scale: 'VAT rate must have no more than two decimal places'
         }
       },
       bankingInformation: {

--- a/server/src/locales/lt.ts
+++ b/server/src/locales/lt.ts
@@ -119,6 +119,8 @@ export default {
         address: 'Adresas iki 255 simbolių yra privalomas',
         email: 'Tinkamas el. pašto adresas yra privalomas'
       },
+      serviceDate: 'Būtina nurodyti tinkamą paslaugos datą',
+      notes: 'Pastabos negali viršyti 2 000 simbolių',
       services: {
         required: 'Būtina bent viena paslauga',
         description: 'Aprašymas iki 200 simbolių yra privalomas',
@@ -133,7 +135,12 @@ export default {
         amount: {
           number: 'Suma turi būti skaičius',
           min: 'Suma turi būti bent 0.01',
-          max: 'Suma negali viršyti 10,000,000'
+          max: 'Suma negali viršyti 10,000,000',
+          scale: 'Suma gali turėti ne daugiau kaip du skaitmenis po kablelio'
+        },
+        vatRate: {
+          scale:
+            'PVM tarifas gali turėti ne daugiau kaip du skaitmenis po kablelio'
         }
       },
       bankingInformation: {

--- a/server/src/test/factories/invoice.ts
+++ b/server/src/test/factories/invoice.ts
@@ -12,6 +12,8 @@ import { bankingInformationFactory } from './banking-information';
 export const invoiceFactory = Factory.define<InvoiceBody>(({ sequence }) => ({
   id: sequence,
   date: new Date().toISOString().split('T')[0],
+  serviceDate: new Date().toISOString().split('T')[0],
+  notes: null,
   userId: 1,
   senderId: 1,
   receiverId: 1,
@@ -41,6 +43,8 @@ export const invoiceFromDbFactory = Factory.define<InvoiceFromDb>(
   ({ sequence }) => ({
     id: sequence,
     date: new Date().toISOString().split('T')[0],
+    serviceDate: new Date().toISOString().split('T')[0],
+    notes: null,
     totalAmount: '1000.00',
     subtotalAmount: '1000.00',
     vatAmount: '0.00',
@@ -87,6 +91,7 @@ export const invoiceFromDbFactory = Factory.define<InvoiceFromDb>(
     services: [
       {
         id: sequence,
+        position: 0,
         description: `Service ${sequence}`,
         unit: 'hour',
         quantity: '10',
@@ -127,6 +132,7 @@ export const invoiceSenderFactory = Factory.define<InvoiceSenderBody>(
 export const invoiceServiceFactory = Factory.define<InvoiceServiceBody>(
   ({ sequence }) => ({
     id: sequence,
+    position: 0,
     description: `Service ${sequence}`,
     unit: 'hour',
     quantity: 10,

--- a/server/src/utils/__tests__/invoice.ts
+++ b/server/src/utils/__tests__/invoice.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { calculateInvoiceTotals, positionInvoiceServices } from '../invoice';
+
+describe('invoice utilities', () => {
+  it('rounds each line subtotal to cents before calculating its VAT', () => {
+    expect(
+      calculateInvoiceTotals([
+        { quantity: 1.005, amount: '10.00', vatRate: '21.00' },
+        { quantity: 1.5, amount: '0.01', vatRate: '0.00' }
+      ])
+    ).toEqual({
+      subtotalAmount: '10.07',
+      vatAmount: '2.11',
+      totalAmount: '12.18'
+    });
+  });
+
+  it('calculates authoritative totals from lines without submitted totals', () => {
+    const submittedInvoice = {
+      subtotalAmount: '999.00',
+      vatAmount: '999.00',
+      totalAmount: '999.00',
+      services: [{ quantity: 2, amount: 12.34, vatRate: 21 }]
+    };
+
+    expect(calculateInvoiceTotals(submittedInvoice.services)).toEqual({
+      subtotalAmount: '24.68',
+      vatAmount: '5.18',
+      totalAmount: '29.86'
+    });
+  });
+
+  it('assigns persisted positions from submitted array order', () => {
+    expect(
+      positionInvoiceServices([{ id: 20 }, { id: 10 }]).map(
+        ({ id, position }) => ({ id, position })
+      )
+    ).toEqual([
+      { id: 20, position: 0 },
+      { id: 10, position: 1 }
+    ]);
+  });
+});

--- a/server/src/utils/invoice.ts
+++ b/server/src/utils/invoice.ts
@@ -14,18 +14,40 @@ type InvoiceTotalService = Omit<
   vatRate?: number | string | null;
 };
 
-const toMoney = (amountInCents: number) => (amountInCents / 100).toFixed(2);
+const parseScaledDecimal = (
+  value: number | string | null | undefined,
+  scale: number
+) => {
+  const decimal = String(value ?? 0).trim();
+  const match = decimal.match(/^(\d+)(?:\.(\d+))?$/);
+
+  if (!match) return 0n;
+
+  const factor = 10n ** BigInt(scale);
+  const fraction = (match[2] || '').padEnd(scale, '0').slice(0, scale);
+
+  return BigInt(match[1]) * factor + BigInt(fraction || '0');
+};
+
+const roundPositiveDivision = (value: bigint, divisor: bigint) =>
+  (value + divisor / 2n) / divisor;
+
+const toMoney = (amountInCents: bigint) =>
+  `${amountInCents / 100n}.${String(amountInCents % 100n).padStart(2, '0')}`;
 
 export const calculateInvoiceTotals = (
   services: Array<InvoiceTotalService>
 ): InvoiceTotals => {
   const totals = services.reduce(
     (acc, service) => {
-      const subtotalCents = Math.round(
-        Number(service.amount) * Number(service.quantity) * 100
+      const subtotalCents = roundPositiveDivision(
+        parseScaledDecimal(service.amount, 2) *
+          parseScaledDecimal(service.quantity, 4),
+        10_000n
       );
-      const vatCents = Math.round(
-        subtotalCents * (Number(service.vatRate ?? 0) / 100)
+      const vatCents = roundPositiveDivision(
+        subtotalCents * parseScaledDecimal(service.vatRate, 2),
+        10_000n
       );
 
       return {
@@ -33,7 +55,7 @@ export const calculateInvoiceTotals = (
         vatCents: acc.vatCents + vatCents
       };
     },
-    { subtotalCents: 0, vatCents: 0 }
+    { subtotalCents: 0n, vatCents: 0n }
   );
 
   return {
@@ -42,3 +64,6 @@ export const calculateInvoiceTotals = (
     totalAmount: toMoney(totals.subtotalCents + totals.vatCents)
   };
 };
+
+export const positionInvoiceServices = <T extends object>(services: Array<T>) =>
+  services.map((service, position) => ({ ...service, position }));

--- a/server/src/utils/json.ts
+++ b/server/src/utils/json.ts
@@ -1,6 +1,9 @@
 import { AnyColumn, InferColumnsDataTypes, SQL, sql } from 'drizzle-orm';
 
-export function jsonAgg<T extends Record<string, AnyColumn>>(select: T) {
+export function jsonAgg<T extends Record<string, AnyColumn>>(
+  select: T,
+  orderBy?: AnyColumn
+) {
   const chunks: SQL[] = [];
 
   Object.entries(select).forEach(([key, column], index) => {
@@ -10,7 +13,7 @@ export function jsonAgg<T extends Record<string, AnyColumn>>(select: T) {
 
   return sql<InferColumnsDataTypes<T>[]>`
     coalesce(
-      json_agg(json_build_object(${sql.join(chunks)})),
+      json_agg(json_build_object(${sql.join(chunks)}) ${orderBy ? sql`ORDER BY ${orderBy}` : sql.empty()}),
       '[]'
     )
   `;

--- a/shared/types/src/invoice.ts
+++ b/shared/types/src/invoice.ts
@@ -91,6 +91,7 @@ export const invoiceNumberSchema = z
 
 export const invoiceServiceBodySchema = z.object({
   id: z.coerce.number().optional(),
+  position: z.coerce.number().int().min(0).optional(),
   description: z
     .string()
     .min(1, 'validation.invoice.services.description')
@@ -107,8 +108,20 @@ export const invoiceServiceBodySchema = z.object({
   amount: z.coerce
     .number('validation.invoice.services.amount.number')
     .min(0.01, 'validation.invoice.services.amount.min')
-    .max(10000000, 'validation.invoice.services.amount.max'),
-  vatRate: z.coerce.number().min(0).max(100).optional(),
+    .max(10000000, 'validation.invoice.services.amount.max')
+    .refine(
+      (amount) => Number(amount.toFixed(2)) === amount,
+      'validation.invoice.services.amount.scale'
+    ),
+  vatRate: z.coerce
+    .number()
+    .min(0)
+    .max(100)
+    .refine(
+      (vatRate) => Number(vatRate.toFixed(2)) === vatRate,
+      'validation.invoice.services.vatRate.scale'
+    )
+    .optional(),
   vatExemptionReason: z.string().trim().max(255).nullish()
 });
 
@@ -155,7 +168,9 @@ export const invoiceBodySchema = z
     invoiceId: invoiceNumberSchema.nullish().or(z.literal('')),
     invoiceSeries: invoiceNumberSeriesSchema.nullish(),
     date: z.iso.date('validation.invoice.date'),
+    serviceDate: z.iso.date('validation.invoice.serviceDate'),
     dueDate: z.iso.date('validation.invoice.dueDate'),
+    notes: z.string().trim().max(2000, 'validation.invoice.notes').nullish(),
     sender: invoiceSenderBodySchema,
     senderSignature: z.any().optional(),
     receiverSignature: z.string().nullish(),


### PR DESCRIPTION
### Overview

- Extend draft invoices with service dates, recipient-visible notes, and persisted line ordering backed by a safe migration.
- Align client and server invoice calculations on deterministic cent rounding while rejecting unsupported decimal scales and recalculating submitted totals server-side.
- Add accessible line reordering, profile-derived due-date behavior, lazy unsaved previews, localized navigation guards, and PDF output for the expanded invoice data.
- Expand focused client, server, and existing invoice draft E2E coverage for the hardened editor workflow.